### PR TITLE
Feature/paas location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 language: java
 jdk:
 - oraclejdk7

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,8 @@
     <parent>
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-downstream-parent</artifactId>
-        <version>0.10.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.10.0-SNAPSHOT</version>
+        <!-- BROOKLYN_VERSION -->
     </parent>
 
     <artifactId>brooklyn-cloudfoundry</artifactId>
@@ -100,7 +101,6 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.11</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>
@@ -110,34 +110,11 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <!--
-                         If you wish to override this list in the component (child) pom, ensure you use
-                             <excludes combine.children="merge">
-                         so that the child pom entries replace the parent entries
-                     -->
                     <excludes combine.children="append">
-                        <!-- git and IDE project files -->
-                        <!-- see https://issues.apache.org/jira/browse/RAT-107 -->
-                        <exclude>**/.git/**</exclude>
-                        <exclude>**/.gitignore</exclude>
-                        <exclude>**/.idea/**</exclude>
-                        <exclude>**/*.iml</exclude>
-                        <exclude>**/.classpath/**</exclude>
-                        <exclude>**/.project</exclude>
-                        <exclude>**/.settings/**</exclude>
-                        <exclude>**/*.log</exclude>
-                        <exclude>**/brooklyn*.log.*</exclude>
-                        <exclude>**/target/**</exclude>
-                        <!-- files not requiring licence -->
                         <exclude>README.md</exclude>
-                        <exclude>LICENSE.md</exclude>
-                        <exclude>.travis.yml</exclude>
-                        <exclude>**/*.yaml</exclude>
                     </excludes>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version>
-        <cloudfoundry.client.version>1.1.2</cloudfoundry.client.version>
+        <cloudfoundry.client.version>1.1.3</cloudfoundry.client.version>
         <mockito.version>1.10.19</mockito.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,12 @@
     <packaging>jar</packaging>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Brooklyn CloudFoundry parent project</name>
+    <name>Brooklyn CloudFoundry project</name>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.entry>org.apache.brooklyn.cloudfoundry.BrooklynCloudFoundryMain</project.entry>
-        <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version> <!-- BROOKLYN_VERSION -->
+        <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version>
+        <cloudfoundry.client.version>1.1.2</cloudfoundry.client.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
 
     <licenses>
@@ -48,35 +47,53 @@
         </license>
     </licenses>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.brooklyn</groupId>
-                <artifactId>brooklyn-all</artifactId>
-                <version>${brooklyn.version}</version>
-            </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-all</artifactId>
+            <version>${brooklyn.version}</version>
+        </dependency>
 
-            <dependency>
-                <groupId>org.apache.brooklyn</groupId>
-                <artifactId>brooklyn-core</artifactId>
-                <version>${brooklyn.version}</version>
-            </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-core</artifactId>
+            <version>${brooklyn.version}</version>
+        </dependency>
 
-            <dependency>
-                <groupId>org.apache.brooklyn</groupId>
-                <artifactId>brooklyn-api</artifactId>
-                <version>${brooklyn.version}</version>
-            </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-api</artifactId>
+            <version>${brooklyn.version}</version>
+        </dependency>
 
-            <dependency>
-                <!-- this gives us flexible and easy-to-use logging; just edit logback-custom.xml! -->
-                <groupId>org.apache.brooklyn</groupId>
-                <artifactId>brooklyn-logback-xml</artifactId>
-                <version>${brooklyn.version}</version>
-            </dependency>
+        <dependency>
+            <groupId>org.cloudfoundry</groupId>
+            <artifactId>cloudfoundry-client-lib</artifactId>
+            <version>${cloudfoundry.client.version}</version>
+        </dependency>
 
-        </dependencies>
-    </dependencyManagement>
+        <!-- http://mvnrepository.com/artifact/org.mockito/mockito-all -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
+        </dependency>
+
+        <dependency>
+            <!-- this gives us flexible and easy-to-use logging; just edit logback-custom.xml! -->
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-logback-xml</artifactId>
+            <version>${brooklyn.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-core</artifactId>
+            <version>${brooklyn.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -55,11 +55,6 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         super(properties);
     }
 
-    public CloudFoundryPaasLocation(CloudFoundryClient client) {
-        super();
-        this.client = client;
-    }
-
     @Override
     public void init() {
         super.init();
@@ -69,7 +64,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         }
     }
 
-    private synchronized void login() {
+    public synchronized void login() {
         if ((accessToken == null) || (accessToken.isExpired())) {
             accessToken = client.login();
         }
@@ -89,7 +84,6 @@ public class CloudFoundryPaasLocation extends AbstractLocation
     }
 
     public CloudFoundryClient getClient() {
-        login();
         return client;
     }
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -81,8 +81,8 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         return client;
     }
 
-    public void setClient(CloudFoundryClient client){
-        this.client =  client;
+    public void setClient(CloudFoundryClient client) {
+        this.client = client;
     }
 
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.cloudfoundry.location;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Map;
 
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -48,18 +49,21 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         super();
     }
 
+    public CloudFoundryPaasLocation(Map<?, ?> properties) {
+        super(properties);
+    }
+
+    public CloudFoundryPaasLocation(CloudFoundryClient client) {
+        super();
+        this.client = client;
+    }
+
     @Override
     public void init() {
         super.init();
-    }
-
-    private synchronized void setUpClient() {
         if (client == null) {
-            CloudCredentials credentials =
-                    new CloudCredentials(getConfig(CF_USER), getConfig(CF_PASSWORD));
-            client = new CloudFoundryClient(credentials,
-                    getTargetURL(getConfig(CF_ENDPOINT)),
-                    getConfig(CF_ORG), getConfig(CF_SPACE), true);
+            client = new CloudFoundryClient(new CloudCredentials(getConfig(CF_USER), getConfig(CF_PASSWORD)),
+                    getTargetURL(getConfig(CF_ENDPOINT)), getConfig(CF_ORG), getConfig(CF_SPACE), true);
             client.login();
         }
     }
@@ -77,13 +81,8 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         }
     }
 
-    protected CloudFoundryClient getClient() {
-        setUpClient();
+    public CloudFoundryClient getClient() {
         return client;
-    }
-
-    public void setClient(CloudFoundryClient client) {
-        this.client = client;
     }
 
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -42,7 +42,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation
     public static ConfigKey<String> CF_ENDPOINT = ConfigKeys.newStringConfigKey("endpoint");
     public static ConfigKey<String> CF_SPACE = ConfigKeys.newStringConfigKey("space");
 
-    CloudFoundryClient client;
+    private CloudFoundryClient client;
 
     public CloudFoundryPaasLocation() {
         super();
@@ -53,7 +53,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         super.init();
     }
 
-    public void setUpClient() {
+    private synchronized void setUpClient() {
         if (client == null) {
             CloudCredentials credentials =
                     new CloudCredentials(getConfig(CF_USER), getConfig(CF_PASSWORD));
@@ -77,7 +77,8 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         }
     }
 
-    public CloudFoundryClient getClient() {
+    protected CloudFoundryClient getClient() {
+        setUpClient();
         return client;
     }
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.location.AbstractLocation;
+import org.apache.brooklyn.location.paas.PaasLocation;
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CloudFoundryPaasLocation extends AbstractLocation
+        implements PaasLocation, CloudFoundryPaasLocationConfig {
+
+    public static final Logger log = LoggerFactory.getLogger(CloudFoundryPaasLocation.class);
+
+    public static ConfigKey<String> CF_USER = ConfigKeys.newStringConfigKey("user");
+    public static ConfigKey<String> CF_PASSWORD = ConfigKeys.newStringConfigKey("password");
+    public static ConfigKey<String> CF_ORG = ConfigKeys.newStringConfigKey("org");
+    public static ConfigKey<String> CF_ENDPOINT = ConfigKeys.newStringConfigKey("endpoint");
+    public static ConfigKey<String> CF_SPACE = ConfigKeys.newStringConfigKey("space");
+
+    CloudFoundryClient client;
+
+    public CloudFoundryPaasLocation() {
+        super();
+    }
+
+    @Override
+    public void init() {
+        super.init();
+    }
+
+    public void setUpClient() {
+        if (client == null) {
+            CloudCredentials credentials =
+                    new CloudCredentials(getConfig(CF_USER), getConfig(CF_PASSWORD));
+            client = new CloudFoundryClient(credentials,
+                    getTargetURL(getConfig(CF_ENDPOINT)),
+                    getConfig(CF_ORG), getConfig(CF_SPACE), true);
+            client.login();
+        }
+    }
+
+    @Override
+    public String getPaasProviderName() {
+        return "CloudFoundry";
+    }
+
+    private static URL getTargetURL(String target) {
+        try {
+            return URI.create(target).toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("The target URL is not valid: " + e.getMessage());
+        }
+    }
+
+    public CloudFoundryClient getClient() {
+        return client;
+    }
+
+    public void setClient(CloudFoundryClient client){
+        this.client =  client;
+    }
+
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -31,6 +31,7 @@ import org.cloudfoundry.client.lib.CloudCredentials;
 import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
 public class CloudFoundryPaasLocation extends AbstractLocation
         implements PaasLocation, CloudFoundryPaasLocationConfig {
@@ -44,6 +45,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation
     public static ConfigKey<String> CF_SPACE = ConfigKeys.newStringConfigKey("space");
 
     private CloudFoundryClient client;
+    private OAuth2AccessToken accessToken;
 
     public CloudFoundryPaasLocation() {
         super();
@@ -64,7 +66,12 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         if (client == null) {
             client = new CloudFoundryClient(new CloudCredentials(getConfig(CF_USER), getConfig(CF_PASSWORD)),
                     getTargetURL(getConfig(CF_ENDPOINT)), getConfig(CF_ORG), getConfig(CF_SPACE), true);
-            client.login();
+        }
+    }
+
+    private synchronized void login() {
+        if ((accessToken == null) || (accessToken.isExpired())) {
+            accessToken = client.login();
         }
     }
 
@@ -82,6 +89,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation
     }
 
     public CloudFoundryClient getClient() {
+        login();
         return client;
     }
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
@@ -30,14 +30,14 @@ public interface CloudFoundryPaasLocationConfig {
 
     @SetFromFlag("cloudfoundry.instances")
     ConfigKey<Integer> REQUIRED_INSTANCES = ConfigKeys.newIntegerConfigKey(
-            "cloudfoundry.profile.instances", "Required instances to deploy the application", 1);
+            "cloudfoundry.profile.instances", "Number of instances of the application", 1);
 
     @SetFromFlag("cloudfoundry.instances")
     ConfigKey<Integer> REQUIRED_MEMORY = ConfigKeys.newIntegerConfigKey(
-            "cloudfoundry.profile.memory", "Required memory to deploy the application (MB)", 512);
+            "cloudfoundry.profile.memory", "Memory allocated for the application (MB)", 512);
 
     @SetFromFlag("cloudfoundry.instances")
     ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
-            "cloudfoundry.profile.disk", "Required disk to deploy the application (MB)", 1024);
+            "cloudfoundry.profile.disk", "Disk size allocated for the application (MB)", 1024);
 
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+/**
+ * It contains the parameters needed to configure an CloudFoundryPaasLocation. For example, the ConfigKey
+ * {@link #REQUIRED_MEMORY} allows to specify a initial memory amount used in a location.
+ */
+public interface CloudFoundryPaasLocationConfig {
+
+    @SetFromFlag("cloudfoundry.instances")
+    ConfigKey<Integer> REQUIRED_INSTANCES = ConfigKeys.newIntegerConfigKey(
+            "cloudfoundry.profile.instances", "Required instances to deploy the application", 1);
+
+    @SetFromFlag("cloudfoundry.instances")
+    ConfigKey<Integer> REQUIRED_MEMORY = ConfigKeys.newIntegerConfigKey(
+            "cloudfoundry.profile.memory", "Required memory to deploy the application (MB)", 512);
+
+    @SetFromFlag("cloudfoundry.instances")
+    ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
+            "cloudfoundry.profile.disk", "Required disk to deploy the application (MB)", 1024);
+
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolver.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolver.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationRegistry;
+import org.apache.brooklyn.api.location.LocationResolver;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.location.BasicLocationRegistry;
+import org.apache.brooklyn.core.location.LocationConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CloudFoundryPaasLocationResolver implements LocationResolver {
+
+    public static final Logger log = LoggerFactory
+            .getLogger(CloudFoundryPaasLocationResolver.class);
+
+    public static final String CLOUD_FOUNDRY = "cloudfoundry";
+
+    private ManagementContext managementContext;
+
+    @Override
+    public void init(ManagementContext managementContext) {
+        this.managementContext = checkNotNull(managementContext, "managementContext");
+    }
+
+    @Override
+    public String getPrefix() {
+        return CLOUD_FOUNDRY;
+    }
+
+    @Override
+    public boolean accepts(String spec, LocationRegistry registry) {
+        return BasicLocationRegistry.isResolverPrefixForSpec(this, spec, true);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return LocationConfigUtils.isResolverPrefixEnabled(managementContext, getPrefix());
+    }
+
+    @Override
+    public LocationSpec<? extends Location> newLocationSpecFromString(String s, Map<?, ?> map, LocationRegistry locationRegistry) {
+        return LocationSpec
+                .create(CloudFoundryPaasLocation.class)
+                .configure(map);
+    }
+
+}
+

--- a/src/main/resources/META-INF/services/org.apache.brooklyn.api.location.LocationResolver
+++ b/src/main/resources/META-INF/services/org.apache.brooklyn.api.location.LocationResolver
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocationResolver

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationLiveTest.java
@@ -18,14 +18,12 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
-import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -53,18 +51,8 @@ public class CloudFoundryPaasLocationLiveTest {
 
     @Test(groups = {"Live"})
     public void testClientSetUp() {
-        cloudFoundryPaasLocation.getClient();
+        cloudFoundryPaasLocation.login();
         assertNotNull(cloudFoundryPaasLocation.getClient());
-    }
-
-    @Test(groups = {"Live"})
-    public void testClientSetUpPerLocationInstance() {
-        cloudFoundryPaasLocation.getClient();
-        CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
-        cloudFoundryPaasLocation.getClient();
-        CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
-        assertNotNull(client1);
-        assertEquals(client1, client2);
     }
 
     protected CloudFoundryPaasLocation newSampleCloudFoundryLocationForTesting(String spec) {

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationLiveTest.java
@@ -53,15 +53,15 @@ public class CloudFoundryPaasLocationLiveTest {
 
     @Test(groups = {"Live"})
     public void testClientSetUp() {
-        cloudFoundryPaasLocation.setUpClient();
+        cloudFoundryPaasLocation.getClient();
         assertNotNull(cloudFoundryPaasLocation.getClient());
     }
 
     @Test(groups = {"Live"})
     public void testClientSetUpPerLocationInstance() {
-        cloudFoundryPaasLocation.setUpClient();
+        cloudFoundryPaasLocation.getClient();
         CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
-        cloudFoundryPaasLocation.setUpClient();
+        cloudFoundryPaasLocation.getClient();
         CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
         assertEquals(client1, client2);
     }
@@ -73,4 +73,5 @@ public class CloudFoundryPaasLocationLiveTest {
     protected LocalManagementContext newLocalManagementContext() {
         return new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
     }
+
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationLiveTest.java
@@ -63,6 +63,7 @@ public class CloudFoundryPaasLocationLiveTest {
         CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
         cloudFoundryPaasLocation.getClient();
         CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
+        assertNotNull(client1);
         assertEquals(client1, client2);
     }
 

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolverTest.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.cloudfoundry.location;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
@@ -84,12 +83,6 @@ public class CloudFoundryPaasLocationResolverTest {
                 CloudFoundryPaasLocationConfig.REQUIRED_MEMORY.getDefaultValue());
         assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocationConfig.REQUIRED_INSTANCES),
                 CloudFoundryPaasLocationConfig.REQUIRED_INSTANCES.getDefaultValue());
-    }
-
-    @Test
-    void testCloudFoundryClientInitilized() {
-        CloudFoundryPaasLocation cloudFoundryPaasLocation = resolve(LOCATION_SPEC_NAME);
-        assertNull(cloudFoundryPaasLocation.getClient());
     }
 
     private CloudFoundryPaasLocation resolve(String spec) {

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolverTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CloudFoundryPaasLocationResolverTest {
+
+    private LocalManagementContext managementContext;
+    private BrooklynProperties brooklynProperties;
+
+    private final String LOCATION_SPEC_NAME = "cloudfoundry-instance";
+
+    private final String USER = "user";
+    private final String PASSWORD = "password";
+    private final String ORG = "organization";
+    private final String SPACE = "space";
+    private final String ENDPOINT = "endpoint";
+    private final String ADDRESS = "run.pivotal.io";
+
+    @BeforeMethod
+    public void setUp() {
+        managementContext = new LocalManagementContext(BrooklynProperties.Factory.newEmpty());
+        brooklynProperties = managementContext.getBrooklynProperties();
+
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME, "cloudfoundry");
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".user", USER);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".password", PASSWORD);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".org", ORG);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".endpoint", ENDPOINT);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".space", SPACE);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".address", ADDRESS);
+
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".disk",
+                CloudFoundryPaasLocationConfig.REQUIRED_DISK.getDefaultValue());
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".memory",
+                CloudFoundryPaasLocationConfig.REQUIRED_MEMORY.getDefaultValue());
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".instances",
+                CloudFoundryPaasLocationConfig.REQUIRED_INSTANCES.getDefaultValue());
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (managementContext != null) {
+            managementContext.terminate();
+        }
+    }
+
+    @Test
+    public void testCloudFoundryTakesProvidersScopedProperties() {
+        CloudFoundryPaasLocation cloudFoundryPaasLocation = resolve(LOCATION_SPEC_NAME);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_USER), USER);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_PASSWORD), PASSWORD);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_ENDPOINT), ENDPOINT);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_ORG), ORG);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_SPACE), SPACE);
+
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocationConfig.REQUIRED_DISK),
+                CloudFoundryPaasLocationConfig.REQUIRED_DISK.getDefaultValue());
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocationConfig.REQUIRED_MEMORY),
+                CloudFoundryPaasLocationConfig.REQUIRED_MEMORY.getDefaultValue());
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocationConfig.REQUIRED_INSTANCES),
+                CloudFoundryPaasLocationConfig.REQUIRED_INSTANCES.getDefaultValue());
+    }
+
+    @Test
+    void testCloudFoundryClientInitilized() {
+        CloudFoundryPaasLocation cloudFoundryPaasLocation = resolve(LOCATION_SPEC_NAME);
+        assertNull(cloudFoundryPaasLocation.getClient());
+    }
+
+    private CloudFoundryPaasLocation resolve(String spec) {
+        return (CloudFoundryPaasLocation) managementContext.getLocationRegistry().resolve(spec);
+    }
+
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -18,10 +18,12 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import java.util.Map;
+
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -39,25 +41,24 @@ public class CloudFoundryPaasLocationTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.initMocks(this);
-        cloudFoundryPaasLocation = createCloudFoundryPaasLocation(client);
+        cloudFoundryPaasLocation = createCloudFoundryPaasLocation();
     }
 
     @Test
-    public void testSetUpClient() {
-        cloudFoundryPaasLocation.getClient();
+    public void testClientSetUp() {
         assertNotNull(cloudFoundryPaasLocation.getClient());
     }
 
-    @Test
-    public void testClientSingletonManagement() {
-        CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
-        CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
-        assertNotNull(client1);
-        assertEquals(client1, client2);
-    }
+    private CloudFoundryPaasLocation createCloudFoundryPaasLocation() {
+        Map<String, String> m = MutableMap.of();
+        m.put("user", "super_user");
+        m.put("password", "super_secret");
+        m.put("org", "secret_organization");
+        m.put("endpoint", "https://api.super.secret.io");
+        m.put("space", "development");
 
-    private CloudFoundryPaasLocation createCloudFoundryPaasLocation(CloudFoundryClient client) {
-        return new CloudFoundryPaasLocation(client);
+        return (CloudFoundryPaasLocation)
+                mgmt.getLocationRegistry().getLocationManaged("cloudfoundry", m);
     }
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -21,10 +21,7 @@ package org.apache.brooklyn.cloudfoundry.location;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import java.util.Map;
-
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -42,34 +39,25 @@ public class CloudFoundryPaasLocationTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.initMocks(this);
-        cloudFoundryPaasLocation = createCloudFoundryPaasLocation();
+        cloudFoundryPaasLocation = createCloudFoundryPaasLocation(client);
     }
 
     @Test
     public void testSetUpClient() {
-        cloudFoundryPaasLocation.setClient(client);
         cloudFoundryPaasLocation.getClient();
         assertNotNull(cloudFoundryPaasLocation.getClient());
     }
 
     @Test
     public void testClientSingletonManagement() {
-        cloudFoundryPaasLocation.setClient(client);
         CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
         CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
+        assertNotNull(client1);
         assertEquals(client1, client2);
     }
 
-    private CloudFoundryPaasLocation createCloudFoundryPaasLocation() {
-        Map<String, String> m = MutableMap.of();
-        m.put("user", "super_user");
-        m.put("password", "super_secret");
-        m.put("org", "secret_organization");
-        m.put("endpoint", "https://api.super.secret.io");
-        m.put("space", "development");
-
-        return (CloudFoundryPaasLocation)
-                mgmt.getLocationRegistry().getLocationManaged("cloudfoundry", m);
+    private CloudFoundryPaasLocation createCloudFoundryPaasLocation(CloudFoundryClient client) {
+        return new CloudFoundryPaasLocation(client);
     }
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Map;
+
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CloudFoundryPaasLocationTest extends BrooklynAppUnitTestSupport {
+
+    protected CloudFoundryPaasLocation cloudFoundryPaasLocation;
+
+    @Mock
+    protected CloudFoundryClient client;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.initMocks(this);
+        cloudFoundryPaasLocation = createCloudFoundryPaasLocation();
+    }
+
+    @Test
+    public void testSetUpClient(){
+        cloudFoundryPaasLocation.setClient(client);
+        cloudFoundryPaasLocation.setUpClient();
+        assertNotNull(cloudFoundryPaasLocation.getClient());
+    }
+
+    @Test
+    public void testClientSingletonManagement() {
+        cloudFoundryPaasLocation.setClient(client);
+
+        CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
+        cloudFoundryPaasLocation.setUpClient();
+        CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
+        assertEquals(client1, client2);
+    }
+
+    private CloudFoundryPaasLocation createCloudFoundryPaasLocation(){
+        Map<String, String> m = MutableMap.of();
+        m.put("user", "super_user");
+        m.put("password", "super_secret");
+        m.put("org", "secret_organization");
+        m.put("endpoint", "https://api.super.secret.io");
+        m.put("space", "development");
+
+        return (CloudFoundryPaasLocation)
+                mgmt.getLocationRegistry().getLocationManaged("cloudfoundry", m);
+    }
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -48,16 +48,14 @@ public class CloudFoundryPaasLocationTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testSetUpClient() {
         cloudFoundryPaasLocation.setClient(client);
-        cloudFoundryPaasLocation.setUpClient();
+        cloudFoundryPaasLocation.getClient();
         assertNotNull(cloudFoundryPaasLocation.getClient());
     }
 
     @Test
     public void testClientSingletonManagement() {
         cloudFoundryPaasLocation.setClient(client);
-
         CloudFoundryClient client1 = cloudFoundryPaasLocation.getClient();
-        cloudFoundryPaasLocation.setUpClient();
         CloudFoundryClient client2 = cloudFoundryPaasLocation.getClient();
         assertEquals(client1, client2);
     }


### PR DESCRIPTION
Adding `CloudFoundryPaasLocation`.
- `CloudFoundryPaasLocation` allows to Cloud Foundry-based platforms to be pointed from Brooklyn.
- A resolver for `CloudFoundryPaasLocation` was added. Then, this location can be resolved using the  prefix `cloudfoundry`.
- Some simple unit and live tests were added.
