### PR TITLE
Feature/paas application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,14 @@
             <artifactId>brooklyn-logback-xml</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-core</artifactId>
+            <version>${brooklyn.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasApplication.java
@@ -18,29 +18,18 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import org.apache.brooklyn.cloudfoundry.location.paas.DeploymentPaasApplicationLocation;
 import org.apache.brooklyn.cloudfoundry.location.paas.PaasApplication;
-import org.apache.brooklyn.core.location.AbstractLocation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class CloudFoundryPaasLocation extends AbstractLocation
-        implements DeploymentPaasApplicationLocation, CloudFoundryPaasLocationConfig {
+public class CloudFoundryPaasApplication implements PaasApplication {
 
-    public static final Logger log = LoggerFactory.getLogger(CloudFoundryPaasLocation.class);
+    private final CloudFoundryPaasLocation platform;
 
-    @Override
-    public String getPaasProviderName() {
-        return "cloudfoundry";
+    public CloudFoundryPaasApplication(CloudFoundryPaasLocation platform) {
+        this.platform = platform;
     }
 
-    @Override
-    public PaasApplication deploy() {
-        return new CloudFoundryPaasApplication(this);
+    public CloudFoundryPaasLocation getPlatform() {
+        return platform;
     }
 
-    @Override
-    public void undeploy(PaasApplication application) {
-
-    }
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasApplication.java
@@ -28,8 +28,26 @@ public class CloudFoundryPaasApplication implements PaasApplication {
         this.platform = platform;
     }
 
-    public CloudFoundryPaasLocation getPlatform() {
-        return platform;
+    public void init() {
+        deployApplication();
     }
 
+    private void deployApplication() {
+        //TODO client.createApplication(...)
+    }
+
+    @Override
+    public void start() {
+        //TODO client...
+    }
+
+    @Override
+    public void stop() {
+        //TODO client...
+    }
+
+    @Override
+    public void restart() {
+        //TODO client...
+    }
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasApplicationImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasApplicationImpl.java
@@ -18,7 +18,34 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import org.apache.brooklyn.cloudfoundry.location.paas.PaasApplication;
+public class CloudFoundryPaasApplicationImpl implements CloudFoundryPaasApplication {
 
-public interface CloudFoundryPaasApplication extends PaasApplication {
+    private final CloudFoundryPaasLocation platform;
+
+    public CloudFoundryPaasApplicationImpl(CloudFoundryPaasLocation platform) {
+        this.platform = platform;
+    }
+
+    public void init() {
+        deployApplication();
+    }
+
+    private void deployApplication() {
+        //TODO client.createApplication(...)
+    }
+
+    @Override
+    public void start() {
+        //TODO client...
+    }
+
+    @Override
+    public void stop() {
+        //TODO client...
+    }
+
+    @Override
+    public void restart() {
+        //TODO client...
+    }
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -51,7 +51,9 @@ public class CloudFoundryPaasLocation extends AbstractLocation
 
     @Override
     public void undeploy(PaasApplication application) {
-        //TODO
+        if (deployedApplications.contains(application)) {
+            deployedApplications.remove(application);
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -18,29 +18,50 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import org.apache.brooklyn.cloudfoundry.location.paas.DeploymentPaasApplicationLocation;
+import java.util.Set;
+
+import org.apache.brooklyn.cloudfoundry.location.paas.DeployingPaasApplicationLocation;
 import org.apache.brooklyn.cloudfoundry.location.paas.PaasApplication;
 import org.apache.brooklyn.core.location.AbstractLocation;
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CloudFoundryPaasLocation extends AbstractLocation
-        implements DeploymentPaasApplicationLocation, CloudFoundryPaasLocationConfig {
+        implements DeployingPaasApplicationLocation, CloudFoundryPaasLocationConfig {
 
     public static final Logger log = LoggerFactory.getLogger(CloudFoundryPaasLocation.class);
+
+    private Set<CloudFoundryPaasApplication> deployedApplications;
+
+    public void init() {
+        deployedApplications = MutableSet.of();
+    }
+
+    @Override
+    public CloudFoundryPaasApplication deploy() {
+        CloudFoundryPaasApplication application = createApplication();
+        deployedApplications.add(application);
+        return application;
+    }
+
+    private CloudFoundryPaasApplication createApplication() {
+        return new CloudFoundryPaasApplication(this);
+    }
+
+    @Override
+    public void undeploy(PaasApplication application) {
+        //TODO
+    }
+
+    @Override
+    public Set<CloudFoundryPaasApplication> getDeployedApplications() {
+        return deployedApplications;
+    }
 
     @Override
     public String getPaasProviderName() {
         return "cloudfoundry";
     }
 
-    @Override
-    public PaasApplication deploy() {
-        return new CloudFoundryPaasApplication(this);
-    }
-
-    @Override
-    public void undeploy(PaasApplication application) {
-
-    }
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -46,7 +46,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation
     }
 
     private CloudFoundryPaasApplication createApplication() {
-        return new CloudFoundryPaasApplication(this);
+        return new CloudFoundryPaasApplicationImpl(this);
     }
 
     @Override

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/DeployingPaasApplicationLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/DeployingPaasApplicationLocation.java
@@ -18,12 +18,17 @@
  */
 package org.apache.brooklyn.cloudfoundry.location.paas;
 
+import java.util.Set;
+
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasApplication;
 import org.apache.brooklyn.location.paas.PaasLocation;
 
-public interface DeploymentPaasApplicationLocation extends PaasLocation {
+public interface DeployingPaasApplicationLocation extends PaasLocation {
 
     public PaasApplication deploy();
 
     public void undeploy(PaasApplication application);
+
+    public Set<CloudFoundryPaasApplication> getDeployedApplications();
 
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/DeploymentPaasApplicationLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/DeploymentPaasApplicationLocation.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location.paas;
+
+import org.apache.brooklyn.location.paas.PaasLocation;
+
+public interface DeploymentPaasApplicationLocation extends PaasLocation {
+
+    public PaasApplication deploy();
+
+    public void undeploy(PaasApplication application);
+
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasApplication.java
@@ -19,4 +19,11 @@
 package org.apache.brooklyn.cloudfoundry.location.paas;
 
 public interface PaasApplication {
+
+    public void start();
+
+    public void stop();
+
+    public void restart();
+
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasApplication.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location.paas;
+
+public interface PaasApplication {
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasLocationConfig.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasLocationConfig.java
@@ -45,8 +45,4 @@ public interface PaasLocationConfig {
     @SetFromFlag("paas.disk")
     ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
             "paas.profile.disk", "Disk size allocated for the application (MB)", 1024);
-
-
-
-
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CloudFoundryPaasLocationTest extends BrooklynAppUnitTestSupport {
+
+    protected CloudFoundryPaasLocation cloudFoundryPaasLocation;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
+        cloudFoundryPaasLocation = createCloudFoundryPaasLocation();
+    }
+
+    @Test
+    public void testDeploy() {
+        CloudFoundryPaasApplication deployedApplication = cloudFoundryPaasLocation.deploy();
+
+        assertEquals(cloudFoundryPaasLocation.getDeployedApplications().size(), 1);
+        assertTrue(cloudFoundryPaasLocation.getDeployedApplications().contains(deployedApplication));
+    }
+
+    private CloudFoundryPaasLocation createCloudFoundryPaasLocation() {
+        Map<String, String> m = MutableMap.of();
+        m.put("identity", "super_user");
+        m.put("credential", "super_secret");
+        m.put("org", "secret_organization");
+        m.put("endpoint", "https://api.super.secret.io");
+        m.put("space", "development");
+
+        return (CloudFoundryPaasLocation)
+                mgmt.getLocationRegistry().getLocationManaged("cloudfoundry", m);
+    }
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -46,6 +46,15 @@ public class CloudFoundryPaasLocationTest extends BrooklynAppUnitTestSupport {
         assertTrue(cloudFoundryPaasLocation.getDeployedApplications().contains(deployedApplication));
     }
 
+    @Test
+    public void testUndeploy() {
+        CloudFoundryPaasApplication deployedApplication = cloudFoundryPaasLocation.deploy();
+        assertEquals(cloudFoundryPaasLocation.getDeployedApplications().size(), 1);
+
+        cloudFoundryPaasLocation.undeploy(deployedApplication);
+        assertTrue(cloudFoundryPaasLocation.getDeployedApplications().isEmpty());
+    }
+
     private CloudFoundryPaasLocation createCloudFoundryPaasLocation() {
         Map<String, String> m = MutableMap.of();
         m.put("identity", "super_user");


### PR DESCRIPTION
Adding the first `PaasApplication` and `CloudFoundryPaasApplication`. 
`DeployingPaasApplicationLocation` defines the method to deploy an `PaasApplication`. Then, any `PaasLocation` (such as `CloudFoundryPaasApplication`) can extend this interface in order to provide applications. Currently, `CloudFoundryPaasLocation` implements directly the aforementioned interface, but  some abstract classes will be added in the following steps 

The next step it will be modified the client.
Probably, the `CloudFoundryPaasApplication` will receive an `cf-java-client` instead of a `CloudFoundryPaasLocation`.
