### PR TITLE
VanillaCloudFoundryApplication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
 
     <properties>
         <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version>
+        <!-- TODO updating to Snapshot -->
+        <cloudfoundry.client.version>1.1.3</cloudfoundry.client.version>
     </properties>
 
     <licenses>
@@ -60,6 +62,12 @@
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-api</artifactId>
             <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.cloudfoundry</groupId>
+            <artifactId>cloudfoundry-client-lib</artifactId>
+            <version>${cloudfoundry.client.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplication.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.entity;
+
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.MapConfigKey;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.time.Duration;
+
+@ImplementedBy(VanillaCloudfoundryApplicationImpl.class)
+public interface VanillaCloudfoundryApplication extends Entity, Startable {
+
+    @SetFromFlag("name")
+    ConfigKey<String> APPLICATION_NAME = ConfigKeys.newStringConfigKey(
+            "cloudFoundry.application.name", "Name of the application");
+
+    @SetFromFlag("path")
+    ConfigKey<String> ARTIFACT_PATH = ConfigKeys.newStringConfigKey(
+            "cloudFoundry.application.artifact", "URI of the application");
+
+
+    @SetFromFlag("buildpack")
+    ConfigKey<String> BUILDPACK = ConfigKeys.newStringConfigKey(
+            "cloudFoundry.application.buildpack", "Buildpack to deploy an application");
+
+    @SetFromFlag("env")
+    MapConfigKey<String> ENVS = new MapConfigKey<String>(String.class, "cloudfoundry.application.env",
+            "Enviroment variables for the application", MutableMap.<String, String>of());
+
+    @SetFromFlag("startTimeout")
+    ConfigKey<Duration> START_TIMEOUT = BrooklynConfigKeys.START_TIMEOUT;
+
+    AttributeSensor<String> ROOT_URL =
+            Sensors.newStringSensor("webapp.url", "URL of the application");
+
+    AttributeSensor<CloudFoundryPaasLocation> CLOUDFOUNDRY_LOCATION = Sensors.newSensor(
+            CloudFoundryPaasLocation.class, "cloudFoundryWebApp.paasLocation",
+            "CloudFoundry location used to deploy the application");
+
+    AttributeSensor<Boolean> SERVICE_PROCESS_IS_RUNNING = Sensors.newBooleanSensor(
+            "service.process.isRunning",
+            "Whether the process for the service is confirmed as running");
+
+    AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
+
+
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplicationImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplicationImpl.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.entity;
+
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Iterables;
+
+public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implements VanillaCloudfoundryApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(VanillaCloudfoundryApplicationImpl.class);
+
+    private CloudFoundryPaasLocation cfLocation;
+    protected boolean connectedSensors = false;
+    private String applicationName;
+    private String domain;
+
+    public VanillaCloudfoundryApplicationImpl() {
+        super(MutableMap.of(), null);
+    }
+
+    public VanillaCloudfoundryApplicationImpl(Entity parent) {
+        this(MutableMap.of(), parent);
+    }
+
+    public VanillaCloudfoundryApplicationImpl(Map properties) {
+        this(properties, null);
+    }
+
+    public VanillaCloudfoundryApplicationImpl(Map properties, Entity parent) {
+        super(properties, parent);
+    }
+
+    public void init() {
+        super.init();
+    }
+
+    /**
+     * If custom behaviour is required by sub-classes, consider overriding
+     * {@link #doStart(java.util.Collection)})}.
+     */
+    @Override
+    public final void start(final Collection<? extends Location> locations) {
+        if (DynamicTasks.getTaskQueuingContext() != null) {
+            doStart(locations);
+        } else {
+            Task<?> task = Tasks.builder().name("start (sequential)").body(new Runnable() {
+                public void run() {
+                    doStart(locations);
+                }
+            }).build();
+            Entities.submit(this, task).getUnchecked();
+        }
+    }
+
+    /**
+     * It is the first approach.
+     * It does not start the entity children.
+     */
+    protected final void doStart(Collection<? extends Location> locations) {
+        ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
+        try {
+            preStart(locations);
+            customStart();
+            log.info("Entity {} was started", new Object[]{this});
+            connectSensors();
+            postStart();
+
+            ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
+        } catch (Throwable t) {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.ON_FIRE);
+            log.error("Error error starting entity {}", this);
+            throw Exceptions.propagate(t);
+        }
+    }
+
+    protected void preStart(Collection<? extends Location> locations) {
+        this.addLocations(locations);
+        if (getLocationOrNull() != null) {
+            cfLocation = getLocationOrNull();
+        } else {
+            throw new ExceptionInInitializerError("Location should not be null in " + this +
+                    " the entity needs a initialized Location");
+        }
+    }
+
+    //Probably it would be better an Optional object
+    private CloudFoundryPaasLocation getLocationOrNull() {
+        return Iterables.get(Iterables
+                .filter(getLocations(), CloudFoundryPaasLocation.class), 0, null);
+    }
+
+    protected void customStart() {
+        deploy();
+        preLaunch();
+        launch();
+        postLaunch();
+    }
+
+    private void deploy() {
+        //TODO deploy application
+        Map<?, ?> params = null;  //params has to contain applicationName, buildpack, path, etc.
+        domain = cfLocation.deploy(params);
+    }
+
+    private void preLaunch() {
+        configureEnv();
+    }
+
+    private void configureEnv() {
+        Map<?, ?> envs = this.getConfig(VanillaCloudfoundryApplication.ENVS);
+        cfLocation.configureEnv(applicationName, (Map<Object, Object>) envs);
+    }
+
+    private void launch() {
+        //TODO, starting the application
+        cfLocation.startApplication(applicationName);
+    }
+
+    private void postLaunch() {
+        //waitForEntityStart();
+        //sensors().set(Attributes.MAIN_URI, domain);
+        sensors().set(VanillaCloudfoundryApplication.ROOT_URL, domain);
+    }
+
+    protected void postStart() {
+        //waitEntityIsUp
+    }
+
+    protected void connectSensors() {
+        connectedSensors = true;
+        //TODO connectServiceIsRunning() and connectServiceUp()
+    }
+
+    @Override
+    public void stop() {
+        if (DynamicTasks.getTaskQueuingContext() != null) {
+            doStop();
+        } else {
+            Task<?> task = Tasks.builder().name("stop").body(new Runnable() {
+                public void run() {
+                    doStop();
+                }
+            }).build();
+            Entities.submit(this, task).getUnchecked();
+        }
+    }
+
+    /**
+     * To be overridden instead of {@link #stop()}; sub-classes should call {@code super.doStop()}
+     * and should add do additional work via tasks, executed using
+     * {@link org.apache.brooklyn.util.core.task.DynamicTasks#queue(String, java.util.concurrent.Callable)}.
+     */
+    protected final void doStop() {
+
+        log.info("Stopping {} in {}", new Object[]{this, getLocationOrNull()});
+
+        if (getAttribute(SERVICE_STATE_ACTUAL)
+                .equals(Lifecycle.STOPPED)) {
+            log.warn("The entity {} is already stopped", new Object[]{this});
+            return;
+        }
+
+        ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPING);
+        try {
+
+            preStop();
+            customStop();
+
+            ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPED);
+            log.info("The entity stop operation {} is completed without errors",
+                    new Object[]{this});
+        } catch (Throwable t) {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.ON_FIRE);
+            throw Exceptions.propagate(t);
+        }
+    }
+
+    protected void preStop() {
+        this.sensors().set(SERVICE_UP, false);
+        disconnectSensors();
+    }
+
+    /**
+     * For disconnecting from the running service. Will be called on stop.
+     */
+    protected void disconnectSensors() {
+        connectedSensors = false;
+        //TODO disconnect
+    }
+
+    protected void customStop() {
+        cfLocation.stop(applicationName);
+    }
+
+    @Override
+    public void restart() {
+        //TODO
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        disconnectSensors();
+    }
+
+    protected CloudFoundryPaasLocation getCloudFoundryLocation() {
+        return cfLocation;
+    }
+
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasClient.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasClient.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+
+public class CloudFoundryPaasClient {
+
+    private final CloudFoundryPaasLocation location;
+    private CloudFoundryClient client;
+
+    public CloudFoundryPaasClient(CloudFoundryPaasLocation location) {
+        this.location = location;
+        setUpClient();
+    }
+
+    private void setUpClient() {
+        if (client == null) {
+            CloudCredentials credentials =
+                    new CloudCredentials(
+                            location.getConfig(CloudFoundryPaasLocationConfig.ACCESS_IDENTITY),
+                            location.getConfig(CloudFoundryPaasLocationConfig.ACCESS_CREDENTIAL));
+            client = new CloudFoundryClient(credentials, null);
+            client.login();
+        }
+    }
+
+    public String deploy(Map<?, ?> params) {
+        String domain;
+        //TODO using client to deploy application
+        //client.createApplication(applicationName, buildpack, memory, disk,...)
+        //pushArtifact(applicationName, artifact);
+
+        //returns the domain of the deployed application
+        return null;
+    }
+
+    public void pushArtifact(String applicationName, String artifact) {
+        //TODO
+        try {
+
+            client.uploadApplication(applicationName, artifact);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void startApplication(String applicationName) {
+        client.startApplication(applicationName);
+    }
+
+    public void setEnv(String applicationName, Map<Object, Object> envs) {
+        //TODO
+        client.getApplication(applicationName).setEnv(envs);
+    }
+
+    public void stop(String applicationName) {
+        //TODO
+        client.stopApplication(applicationName);
+    }
+
+}

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
+import java.util.Map;
+
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.location.paas.PaasLocation;
 import org.slf4j.Logger;
@@ -28,8 +30,44 @@ public class CloudFoundryPaasLocation extends AbstractLocation
 
     public static final Logger log = LoggerFactory.getLogger(CloudFoundryPaasLocation.class);
 
+    private CloudFoundryPaasClient client;
+
+    @Override
+    public void init() {
+        super.init();
+    }
+
+    protected CloudFoundryPaasClient getClient() {
+        if (client == null) {
+            client = new CloudFoundryPaasClient(this);
+        }
+        return client;
+    }
+
     @Override
     public String getPaasProviderName() {
         return "cloudfoundry";
+    }
+
+    /**
+     * Deploy an application in the cloud through client and retrieves the application domain.
+     *
+     * @param params contains the params to deploy and configure the application in the cloud.
+     * @return the application domain.
+     */
+    public String deploy(Map<?, ?> params) {
+        return getClient().deploy(params);
+    }
+
+    public void configureEnv(String applicationName, Map<Object, Object> envs) {
+        getClient().setEnv(applicationName, (Map<Object, Object>) envs);
+    }
+
+    public void startApplication(String applicationName) {
+        getClient().startApplication(applicationName);
+    }
+
+    public void stop(String applicationName) {
+        getClient().stop(applicationName);
     }
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasLocationConfig.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/paas/PaasLocationConfig.java
@@ -34,15 +34,15 @@ public interface PaasLocationConfig {
     @SetFromFlag("endpoint")
     public static ConfigKey<String> CLOUD_ENDPOINT = LocationConfigKeys.CLOUD_ENDPOINT;
 
-    @SetFromFlag("paas.instances")
+    @SetFromFlag("instances")
     ConfigKey<Integer> REQUIRED_INSTANCES = ConfigKeys.newIntegerConfigKey(
             "paas.profile.instances", "Number of instances of the application", 1);
 
-    @SetFromFlag("paas.memory")
+    @SetFromFlag("memory")
     ConfigKey<Integer> REQUIRED_MEMORY = ConfigKeys.newIntegerConfigKey(
             "paas.profile.memory", "Memory allocated for the application (MB)", 512);
 
-    @SetFromFlag("paas.disk")
+    @SetFromFlag("disk_quota")
     ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
             "paas.profile.disk", "Disk size allocated for the application (MB)", 1024);
 

--- a/src/test/resources/example.yml
+++ b/src/test/resources/example.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Vanilla CloudFoundry example
+location:
+    cloudfoundry:
+      user: user@mail.com
+      password: secret
+      org: secret_organization
+      endpoint: https://api.run.secret.io
+      space: development
+      address: run.secret.io
+      memory: 1024
+      disk_quota: 10
+      instances: 1
+
+services:
+- type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudfoundryApplication
+  config:
+      name: vanilla-example
+      path: https://www.server.com/exmpale?dl=1
+      buildpack: https://github.com/cloudfoundry/java-buildpack.git
+  env:
+    env1: value1


### PR DESCRIPTION
`VanillaCloudFoundryApplication`, a generic entity to deploy an application on CloudFoundry.

It contains a schema about how CloudFoundry services would be managed. `CloudFoundryLocation` uses a `CloudFoundryPaasClient` hiding the complexity of `CloudFoundryClient`, which is accessible by an `protected` method in order to simplify the testing.

An example yaml was added to shows how an application can be described.

This PR contains a lot of comments and some parts have not been developed because the current code  is just a sketch.
