### PR TITLE
Integration of CloudFoundry location and Vanilla entity 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <!-- TODO updating to Snapshot -->
         <cloudfoundry.client.version>1.1.3</cloudfoundry.client.version>
         <mockito.version>1.10.19</mockito.version>
+        <mockwebserver.version>2.7.0</mockwebserver.version>
     </properties>
 
     <licenses>
@@ -82,6 +83,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplication.java
@@ -63,11 +63,11 @@ public interface VanillaCloudfoundryApplication extends Entity, Startable {
     ConfigKey<Integer> REQUIRED_INSTANCES = ConfigKeys.newIntegerConfigKey(
             "cloudfoundry.profile.instances", "Number of instances of the application", 1);
 
-    @SetFromFlag("instances")
+    @SetFromFlag("memory")
     ConfigKey<Integer> REQUIRED_MEMORY = ConfigKeys.newIntegerConfigKey(
             "cloudfoundry.profile.memory", "Memory allocated for the application (MB)", 512);
 
-    @SetFromFlag("instances")
+    @SetFromFlag("disk")
     ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
             "cloudfoundry.profile.disk", "Disk size allocated for the application (MB)", 1024);
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplicationImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplicationImpl.java
@@ -163,9 +163,6 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
 
         locations = Locations.getLocationsCheckingAncestors(locations, this);
 
-        Maybe<MachineLocation> ml = Locations.findUniqueMachineLocation(locations);
-        if (ml.isPresent()) return ml.get();
-
         if (locations.isEmpty())
             throw new IllegalArgumentException("No locations specified when starting " + this);
         if (locations.size() != 1 || Iterables.getOnlyElement(locations) == null)

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplicationImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudfoundryApplicationImpl.java
@@ -18,35 +18,62 @@
  */
 package org.apache.brooklyn.cloudfoundry.entity;
 
-
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
+import org.apache.brooklyn.cloudfoundry.utils.LocalResourcesDownloader;
 import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.feed.function.FunctionFeed;
+import org.apache.brooklyn.feed.function.FunctionPollConfig;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.http.HttpTool;
+import org.apache.brooklyn.util.text.Identifiers;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.CountdownTimer;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
 
 public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implements VanillaCloudfoundryApplication {
 
     private static final Logger log = LoggerFactory.getLogger(VanillaCloudfoundryApplicationImpl.class);
+    private static final String DEFAULT_APP_PREFIX = "cf-app-";
 
     private CloudFoundryPaasLocation cfLocation;
-    protected boolean connectedSensors = false;
     private String applicationName;
-    private String domain;
+    private String applicationUrl;
+
+    protected boolean connectedSensors = false;
+    private FunctionFeed serviceProcessIsRunning;
+    private FunctionFeed serviceProcessUp;
 
     public VanillaCloudfoundryApplicationImpl() {
         super(MutableMap.of(), null);
@@ -66,12 +93,24 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
 
     public void init() {
         super.init();
+        initApplicationName();
     }
 
-    /**
-     * If custom behaviour is required by sub-classes, consider overriding
-     * {@link #doStart(java.util.Collection)})}.
-     */
+    private void initApplicationName() {
+        applicationName = getConfig(APPLICATION_NAME);
+        if (Strings.isBlank(applicationName)) {
+            applicationName = DEFAULT_APP_PREFIX + Identifiers.makeRandomId(8);
+        }
+    }
+
+    @Override
+    protected void initEnrichers() {
+        super.initEnrichers();
+        ServiceStateLogic.ServiceNotUpLogic
+                .updateNotUpIndicator(this, SERVICE_PROCESS_IS_RUNNING,
+                        "No information yet on whether this service is running");
+    }
+
     @Override
     public final void start(final Collection<? extends Location> locations) {
         if (DynamicTasks.getTaskQueuingContext() != null) {
@@ -86,14 +125,10 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
         }
     }
 
-    /**
-     * It is the first approach.
-     * It does not start the entity children.
-     */
     protected final void doStart(Collection<? extends Location> locations) {
         ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
         try {
-            preStart(locations);
+            preStart(findLocation(locations));
             customStart();
             log.info("Entity {} was started", new Object[]{this});
             connectSensors();
@@ -107,8 +142,8 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
         }
     }
 
-    protected void preStart(Collection<? extends Location> locations) {
-        this.addLocations(locations);
+    protected void preStart(Location location) {
+        this.addLocations(MutableList.of(location));
         if (getLocationOrNull() != null) {
             cfLocation = getLocationOrNull();
         } else {
@@ -117,7 +152,28 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
         }
     }
 
-    //Probably it would be better an Optional object
+    /*
+     * TODO: avoiding boilerplate code
+     * This method is a copy of getLocations in MachineLifecycleEffectorTasks
+     */
+    protected Location findLocation(@Nullable Collection<? extends Location> locations) {
+        if (locations == null || locations.isEmpty()) {
+            locations = this.getLocations();
+        }
+
+        locations = Locations.getLocationsCheckingAncestors(locations, this);
+
+        Maybe<MachineLocation> ml = Locations.findUniqueMachineLocation(locations);
+        if (ml.isPresent()) return ml.get();
+
+        if (locations.isEmpty())
+            throw new IllegalArgumentException("No locations specified when starting " + this);
+        if (locations.size() != 1 || Iterables.getOnlyElement(locations) == null)
+            throw new IllegalArgumentException("Ambiguous locations detected when starting " + this + ": " + locations);
+        return Iterables.getOnlyElement(locations);
+    }
+
+    //TODO: Probably it would be better an Optional object
     private CloudFoundryPaasLocation getLocationOrNull() {
         return Iterables.get(Iterables
                 .filter(getLocations(), CloudFoundryPaasLocation.class), 0, null);
@@ -131,9 +187,12 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
     }
 
     private void deploy() {
-        //TODO deploy application
-        Map<?, ?> params = null;  //params has to contain applicationName, buildpack, path, etc.
-        domain = cfLocation.deploy(params);
+        Map<String, Object> params = MutableMap.copyOf(this.config().getBag().getAllConfig());
+        params.put(APPLICATION_NAME.getName(), applicationName);
+        if(params.containsKey(ARTIFACT_PATH.getName())) {
+            params.put(ARTIFACT_PATH.getName(), getLocalPath((String) params.get(ARTIFACT_PATH.getName())));
+        }
+        applicationUrl = cfLocation.deploy(params);
     }
 
     private void preLaunch() {
@@ -141,28 +200,73 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
     }
 
     private void configureEnv() {
-        Map<?, ?> envs = this.getConfig(VanillaCloudfoundryApplication.ENVS);
-        cfLocation.configureEnv(applicationName, (Map<Object, Object>) envs);
+        //TODO
+        //Map<?, ?> envs = this.getConfig(VanillaCloudfoundryApplication.ENVS);
+        //cfLocation.configureEnv(applicationName, (Map<Object, Object>) envs);
     }
 
     private void launch() {
-        //TODO, starting the application
         cfLocation.startApplication(applicationName);
     }
 
     private void postLaunch() {
-        //waitForEntityStart();
-        //sensors().set(Attributes.MAIN_URI, domain);
-        sensors().set(VanillaCloudfoundryApplication.ROOT_URL, domain);
+        waitForEntityStart();
+        sensors().set(Attributes.MAIN_URI, URI.create(applicationUrl));
+        sensors().set(VanillaCloudfoundryApplication.ROOT_URL, applicationUrl);
     }
 
     protected void postStart() {
-        //waitEntityIsUp
+        Entities.waitForServiceUp(this, Duration.of(
+                getConfig(BrooklynConfigKeys.START_TIMEOUT).toMilliseconds(),
+                TimeUnit.MILLISECONDS));
     }
 
     protected void connectSensors() {
         connectedSensors = true;
-        //TODO connectServiceIsRunning() and connectServiceUp()
+        connectServiceIsRunning();
+        connectServiceUp();
+    }
+
+    protected void connectServiceIsRunning() {
+        serviceProcessIsRunning = FunctionFeed.builder()
+                .entity(this)
+                .period(Duration.FIVE_SECONDS)
+                .poll(new FunctionPollConfig<Boolean, Boolean>(SERVICE_PROCESS_IS_RUNNING)
+                        .onException(Functions.constant(Boolean.FALSE))
+                        .callable(new Callable<Boolean>() {
+                            public Boolean call() {
+                                return isRunning();
+                            }
+                        }))
+                .build();
+    }
+
+    protected void connectServiceUp() {
+        serviceProcessUp = FunctionFeed.builder()
+                .entity(this)
+                .period(Duration.FIVE_SECONDS)
+                .poll(new FunctionPollConfig<Boolean, Boolean>(SERVICE_UP)
+                        .onException(Functions.constant(Boolean.FALSE))
+                        .callable(new Callable<Boolean>() {
+                            public Boolean call() {
+                                return isRunning();
+                            }
+                        }))
+                .build();
+    }
+
+    public boolean isRunning() {
+        return isApplicationDomainAvailable();
+    }
+
+    protected boolean isApplicationDomainAvailable() {
+        boolean result;
+        try {
+            result = HttpTool.getHttpStatusCode(applicationUrl) == HttpURLConnection.HTTP_OK;
+        } catch (Exception e) {
+            result = false;
+        }
+        return result;
     }
 
     @Override
@@ -214,16 +318,31 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
         disconnectSensors();
     }
 
-    /**
-     * For disconnecting from the running service. Will be called on stop.
-     */
-    protected void disconnectSensors() {
-        connectedSensors = false;
-        //TODO disconnect
-    }
-
     protected void customStop() {
         cfLocation.stop(applicationName);
+        cfLocation.delete(applicationName);
+    }
+
+    protected void disconnectSensors() {
+        connectedSensors = false;
+        disconnectServiceIsRunning();
+        disconnectServiceUp();
+    }
+
+    protected void disconnectServiceIsRunning() {
+        if (serviceProcessIsRunning != null) {
+            serviceProcessIsRunning.stop();
+        }
+        sensors().set(SERVICE_PROCESS_IS_RUNNING, null);
+        sensors().remove(SERVICE_PROCESS_IS_RUNNING);
+    }
+
+    protected void disconnectServiceUp() {
+        if (serviceProcessUp != null) {
+            serviceProcessUp.stop();
+        }
+        sensors().set(SERVICE_UP, null);
+        sensors().remove(SERVICE_UP);
     }
 
     @Override
@@ -235,10 +354,60 @@ public class VanillaCloudfoundryApplicationImpl extends AbstractEntity implement
     public void destroy() {
         super.destroy();
         disconnectSensors();
+        getCloudFoundryLocation().delete(applicationName);
     }
 
     protected CloudFoundryPaasLocation getCloudFoundryLocation() {
         return cfLocation;
     }
 
+
+    private void waitForEntityStart() {
+        if (log.isDebugEnabled()) {
+            log.debug("waiting to ensure {} doesn't abort prematurely", this);
+        }
+        Duration startTimeout = getConfig(START_TIMEOUT);
+        CountdownTimer timer = startTimeout.countdownTimer();
+        boolean isRunningResult = false;
+        long delay = 100;
+        while (!isRunningResult && !timer.isExpired()) {
+            Time.sleep(delay);
+            try {
+                isRunningResult = isRunning();
+            } catch (Exception e) {
+                ServiceStateLogic.setExpectedState(this, Lifecycle.ON_FIRE);
+                // provide extra context info, as we're seeing this happen in strange circumstances
+                throw new IllegalStateException("Error detecting whether " + this +
+                        " is running: " + e, e);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("checked {}, is running returned: {}", this, isRunningResult);
+            }
+            // slow exponential delay -- 1.1^N means after 40 tries and 50s elapsed, it reaches
+            // the max of 5s intervals
+            // TODO use Repeater
+            delay = Math.min(delay * 11 / 10, 5000);
+        }
+        if (!isRunningResult) {
+            String msg = "Software process entity " + this + " did not pass is-running " +
+                    "check within the required " + startTimeout + " limit (" +
+                    timer.getDurationElapsed().toStringRounded() + " elapsed)";
+            log.warn(msg + " (throwing)");
+            ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
+            throw new IllegalStateException(msg);
+        }
+    }
+
+    private String getLocalPath(String uri) {
+        try {
+            File war;
+            war = LocalResourcesDownloader
+                    .downloadResourceInLocalDir(uri);
+            return war.getCanonicalPath();
+        } catch (IOException e) {
+            log.error("Error obtaining local path in {} for artifact {}", this, uri);
+            throw Exceptions.propagate(e);
+        }
+    }
+    
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/utils/LocalResourcesDownloader.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/utils/LocalResourcesDownloader.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.io.FileUtils;
+
+import com.google.common.base.Throwables;
+
+public class LocalResourcesDownloader {
+    private static final String BROOKLYN_DIR = "brooklyn";
+
+    public static File downloadResourceInLocalDir(String url) {
+        File localResource = createLocalFilePathName(
+                findArchiveNameFromUrl(url));
+        LocalResourcesDownloader.downloadResource(url, localResource);
+        return localResource;
+    }
+
+    /**
+     * Generates a tmp directory based on:</br>
+     * TMP_OS_DIRECTORY/brooklyn/ENTITY_ID/RANDOM_STRING(8)
+     *
+     * @return
+     */
+    public static String findATmpDir() {
+        String osTmpDir = new Os.TmpDirFinder().get().get();
+        return osTmpDir + File.separator +
+                BROOKLYN_DIR + File.separator +
+                Strings.makeRandomId(8);
+    }
+
+    public static File createLocalFilePathName(String fileName) {
+        return new File(createLocalPathName(fileName));
+    }
+
+    public static String createLocalPathName(String fileName) {
+        String targetDirName = LocalResourcesDownloader.findATmpDir();
+        String filePathName = targetDirName + File.separator + fileName;
+
+        File targetDir = new File(targetDirName);
+        targetDir.mkdirs();
+
+        return filePathName;
+    }
+
+    public static String findArchiveNameFromUrl(String url) {
+        String name = url.substring(url.lastIndexOf('/') + 1);
+        if (name.indexOf("?") > 0) {
+            Pattern p = Pattern.compile("[A-Za-z0-9_\\-]+\\..(ar|AR)($|(?=[^A-Za-z0-9_\\-]))");
+            Matcher wars = p.matcher(name);
+            if (wars.find()) {
+                name = wars.group();
+            }
+        }
+        return name;
+    }
+
+    public static void downloadResource(String url, File target) {
+        try {
+            downloadResource(new ResourceUtils(null).getResourceFromUrl(url), target);
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public static void downloadResource(InputStream source, File target) {
+        try {
+            FileUtils.copyInputStreamToFile(source, target);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+}
+

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/utils/LocalResourcesDownloader.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/utils/LocalResourcesDownloader.java
@@ -19,8 +19,6 @@
 package org.apache.brooklyn.cloudfoundry.utils;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,7 +30,7 @@ import org.apache.commons.io.FileUtils;
 import com.google.common.base.Throwables;
 
 public class LocalResourcesDownloader {
-    private static final String BROOKLYN_DIR = "brooklyn";
+    public static final String BROOKLYN_DIR = "brooklyn";
 
     public static File downloadResourceInLocalDir(String url) {
         File localResource = createLocalFilePathName(
@@ -41,12 +39,6 @@ public class LocalResourcesDownloader {
         return localResource;
     }
 
-    /**
-     * Generates a tmp directory based on:</br>
-     * TMP_OS_DIRECTORY/brooklyn/ENTITY_ID/RANDOM_STRING(8)
-     *
-     * @return
-     */
     public static String findATmpDir() {
         String osTmpDir = new Os.TmpDirFinder().get().get();
         return osTmpDir + File.separator +
@@ -54,11 +46,11 @@ public class LocalResourcesDownloader {
                 Strings.makeRandomId(8);
     }
 
-    public static File createLocalFilePathName(String fileName) {
+    private static File createLocalFilePathName(String fileName) {
         return new File(createLocalPathName(fileName));
     }
 
-    public static String createLocalPathName(String fileName) {
+    private static String createLocalPathName(String fileName) {
         String targetDirName = LocalResourcesDownloader.findATmpDir();
         String filePathName = targetDirName + File.separator + fileName;
 
@@ -68,7 +60,7 @@ public class LocalResourcesDownloader {
         return filePathName;
     }
 
-    public static String findArchiveNameFromUrl(String url) {
+    private static String findArchiveNameFromUrl(String url) {
         String name = url.substring(url.lastIndexOf('/') + 1);
         if (name.indexOf("?") > 0) {
             Pattern p = Pattern.compile("[A-Za-z0-9_\\-]+\\..(ar|AR)($|(?=[^A-Za-z0-9_\\-]))");
@@ -82,19 +74,10 @@ public class LocalResourcesDownloader {
 
     public static void downloadResource(String url, File target) {
         try {
-            downloadResource(new ResourceUtils(null).getResourceFromUrl(url), target);
+            FileUtils.copyInputStreamToFile(new ResourceUtils(null).getResourceFromUrl(url), target);
         } catch (Exception e) {
             throw Throwables.propagate(e);
         }
     }
 
-    public static void downloadResource(InputStream source, File target) {
-        try {
-            FileUtils.copyInputStreamToFile(source, target);
-        } catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
-    }
-
 }
-

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationLiveTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.entity;
+
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryLiveTest;
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundryLiveTest {
+
+    @Test(groups = {"Live"})
+    public void testDeployApplication() throws IOException {
+        final VanillaCloudfoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudfoundryApplication.class)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_NAME, applicationName)
+                        .configure(VanillaCloudfoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
+                        .configure(VanillaCloudfoundryApplication.BUILDPACK, JAVA_BUILDPACK));
+
+        startInLocationAndCheckEntitySensors(entity, cloudFoundryPaasLocation);
+    }
+
+    @Test(groups = {"Live"})
+    public void testDeployApplicationWithoutDomain() throws IOException {
+        final VanillaCloudfoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudfoundryApplication.class)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_NAME, applicationName)
+                        .configure(VanillaCloudfoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudfoundryApplication.BUILDPACK, JAVA_BUILDPACK));
+
+        startInLocationAndCheckEntitySensors(entity, cloudFoundryPaasLocation);
+    }
+
+    @Test(groups = {"Live"})
+    public void testStopApplication() {
+        final VanillaCloudfoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudfoundryApplication.class)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_NAME, applicationName)
+                        .configure(VanillaCloudfoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
+                        .configure(VanillaCloudfoundryApplication.BUILDPACK, JAVA_BUILDPACK));
+
+        startInLocationAndCheckEntitySensors(entity, cloudFoundryPaasLocation);
+        entity.stop();
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertNull(entity.getAttribute(Startable.SERVICE_UP));
+                assertNull(entity.getAttribute(VanillaCloudfoundryApplication
+                        .SERVICE_PROCESS_IS_RUNNING));
+            }
+        });
+    }
+
+    private void startInLocationAndCheckEntitySensors(final VanillaCloudfoundryApplication entity,
+                                                      CloudFoundryPaasLocation location) {
+        app.start(ImmutableList.of(location));
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                assertTrue(entity.getAttribute(VanillaCloudfoundryApplication
+                        .SERVICE_PROCESS_IS_RUNNING));
+            }
+        });
+        assertFalse(Strings.isBlank(entity.getAttribute(Attributes.MAIN_URI).toString()));
+        assertFalse(Strings.isBlank(entity.getAttribute(VanillaCloudfoundryApplication.ROOT_URL)));
+    }
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
@@ -30,11 +30,13 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
 import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
 import org.apache.brooklyn.util.text.Strings;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -85,6 +87,17 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
                         .configure(VanillaCloudfoundryApplication.BUILDPACK, Strings.makeRandomId(20)));
 
         startEntityInLocationAndCheckSensors(entity, location);
+    }
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testDeployApplicationWithoutLocation() throws IOException {
+        final VanillaCloudfoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudfoundryApplication.class)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_NAME, APPLICATION_NAME)
+                        .configure(VanillaCloudfoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_DOMAIN, DOMAIN)
+                        .configure(VanillaCloudfoundryApplication.BUILDPACK, Strings.makeRandomId(20)));
+        entity.start(ImmutableList.<Location>of());
     }
 
     @Test

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.entity;
+
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.text.Strings;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.mockwebserver.Dispatcher;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnitTest {
+
+    private static final String APP_PATH = "vanilla-cf-app-test";
+
+    private MockWebServer mockWebServer;
+    private HttpUrl serverUrl;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.initMocks(this);
+        mockWebServer = new MockWebServer();
+        serverUrl = mockWebServer.url(APP_PATH);
+
+        mockWebServer.setDispatcher(getGenericDispatcher());
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        super.tearDown();
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testDeployApplication() throws IOException {
+        CloudFoundryPaasLocation location = spy(cloudFoundryPaasLocation);
+        doNothing().when(location).startApplication(anyString());
+        doReturn(serverUrl.url().toString()).when(location).deploy(anyMap());
+
+        final VanillaCloudfoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudfoundryApplication.class)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_NAME, APPLICATION_NAME)
+                        .configure(VanillaCloudfoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_DOMAIN, DOMAIN)
+                        .configure(VanillaCloudfoundryApplication.BUILDPACK, Strings.makeRandomId(20)));
+
+        startEntityInLocationAndCheckSensors(entity, location);
+    }
+
+    @Test
+    public void testStopApplication() {
+        CloudFoundryPaasLocation location = spy(cloudFoundryPaasLocation);
+        doNothing().when(location).startApplication(anyString());
+        doNothing().when(location).stop(anyString());
+        doNothing().when(location).delete(anyString());
+        doReturn(serverUrl.url().toString()).when(location).deploy(anyMap());
+
+        final VanillaCloudfoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudfoundryApplication.class)
+                        .configure(VanillaCloudfoundryApplication.APPLICATION_NAME, APPLICATION_NAME));
+
+        startEntityInLocationAndCheckSensors(entity, location);
+        entity.stop();
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertNull(entity.getAttribute(Startable.SERVICE_UP));
+                assertNull(entity.getAttribute(VanillaCloudfoundryApplication
+                        .SERVICE_PROCESS_IS_RUNNING));
+            }
+        });
+    }
+
+    private void startEntityInLocationAndCheckSensors(final VanillaCloudfoundryApplication entity,
+                                                      CloudFoundryPaasLocation location) {
+        entity.start(ImmutableList.of(location));
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                assertTrue(entity.getAttribute(VanillaCloudfoundryApplication
+                        .SERVICE_PROCESS_IS_RUNNING));
+            }
+        });
+        assertEquals(entity.getAttribute(Attributes.MAIN_URI).toString(), serverUrl.url().toString());
+        assertEquals(entity.getAttribute(VanillaCloudfoundryApplication.ROOT_URL), serverUrl.url().toString());
+    }
+
+    private Dispatcher getGenericDispatcher() {
+        return new Dispatcher() {
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                if (request.getPath().equals("/" + APP_PATH)) {
+                    return new MockResponse().setResponseCode(200);
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+    }
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryYamlTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryYamlTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.entity;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.launcher.camp.SimpleYamlLauncher;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.Test;
+
+public class VanillaCloudFoundryYamlTest {
+
+    @Test(groups = {"Live"})
+    public void deployWebappWithServicesFromYaml() {
+        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
+        launcher.setShutdownAppsOnExit(true);
+        Application app = launcher.launchAppYaml("vanilla-cf-stadalone.yml").getApplication();
+
+        final VanillaCloudfoundryApplication entity = (VanillaCloudfoundryApplication)
+                findChildEntitySpecByPlanId(app, "vanilla-app");
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                assertTrue(entity.getAttribute(VanillaCloudfoundryApplication
+                        .SERVICE_PROCESS_IS_RUNNING));
+
+                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                assertNotNull(entity.getAttribute(Attributes.MAIN_URI).toString());
+                assertNotNull(entity.getAttribute(VanillaCloudfoundryApplication.ROOT_URL));
+            }
+        });
+    }
+
+    private Entity findChildEntitySpecByPlanId(Application app, String planId) {
+        for (Entity child : app.getChildren()) {
+            String childPlanId = child.getConfig(BrooklynCampConstants.PLAN_ID);
+            if ((childPlanId != null) && (childPlanId.equals(planId))) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/utils/LocalResourcesDownloaderTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/utils/LocalResourcesDownloaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.utils;
+
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.io.FileUtils;
+import org.testng.annotations.Test;
+
+public class LocalResourcesDownloaderTest {
+
+    private static String ARTIFACT_NAME = "brooklyn-example-hello-world-sql-webapp-in-paas.war";
+    private static String ARTIFACT_URL = "classpath://" + ARTIFACT_NAME;
+    private static String TEMP_FOLDER = new Os.TmpDirFinder().get().get();
+
+    @Test
+    public void testDownloadResourceInLocalDir() {
+        File localFile = LocalResourcesDownloader.downloadResourceInLocalDir(ARTIFACT_URL);
+        assertTrue(localFile.exists());
+        assertTrue(localFile.canRead());
+        assertTrue(localFile.getAbsolutePath().startsWith(TEMP_FOLDER));
+    }
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testExceptionDownloadingInLocalDir() {
+        LocalResourcesDownloader.downloadResourceInLocalDir(Strings.makeRandomId(2));
+    }
+
+    @Test
+    public void testFindATmpDir() {
+        assertTrue(LocalResourcesDownloader.findATmpDir().matches(TEMP_FOLDER + File.separator
+                + LocalResourcesDownloader.BROOKLYN_DIR + File.separator + "[a-zA-Z0-9]+"));
+    }
+
+    @Test
+    @SuppressWarnings("all")
+    public void testDownloadResource() throws URISyntaxException, IOException {
+        File artifact = new File(getClass().getClassLoader().getResource(ARTIFACT_NAME).toURI());
+        File tmpFile = new File("tmp-file");
+        LocalResourcesDownloader.downloadResource(ARTIFACT_URL, tmpFile);
+        assertTrue(FileUtils.contentEquals(artifact, tmpFile));
+        tmpFile.delete();
+    }
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testExceptionDownloadingResource() throws URISyntaxException {
+        File file = new File("tmp-file");
+        LocalResourcesDownloader.downloadResource(Strings.makeRandomId(8), file);
+    }
+}

--- a/src/test/resources/cloudfoundry-location-example.yml
+++ b/src/test/resources/cloudfoundry-location-example.yml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Vanilla CloudFoundry example
+location:
+  cloudfoundry:
+    user: user@mail.com
+    password: secret
+    org: secret_organization
+    endpoint: https://api.run.secret.io
+    space: development
+    address: run.secret.io
+    memory: 1024
+    disk_quota: 10
+    instances: 1
+services:
+- type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudfoundryApplication
+  id: vanilla-app
+  brooklyn.config:
+    name: vanilla-cf-app-example
+    path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
+    buildpack: https://github.com/cloudfoundry/java-buildpack.git
+    domain: cfapps.io
+    memory: 512
+    disk_quota: 2048
+    instances: 1

--- a/src/test/resources/vanilla-cf-stadalone.yml
+++ b/src/test/resources/vanilla-cf-stadalone.yml
@@ -17,23 +17,15 @@
 # under the License.
 #
 name: Vanilla CloudFoundry example
-location:
-    cloudfoundry:
-      user: user@mail.com
-      password: secret
-      org: secret_organization
-      endpoint: https://api.run.secret.io
-      space: development
-      address: run.secret.io
-      memory: 1024
-      disk_quota: 10
-      instances: 1
-
+location: pivotal-ws
 services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudfoundryApplication
-  config:
-      name: vanilla-example
-      path: https://www.server.com/exmpale?dl=1
-      buildpack: https://github.com/cloudfoundry/java-buildpack.git
-  env:
-    env1: value1
+  id: vanilla-app
+  brooklyn.config:
+    name: vanilla-cf-app-example
+    path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
+    buildpack: https://github.com/cloudfoundry/java-buildpack.git
+    domain: cfapps.io
+    memory: 512
+    disk_quota: 2048
+    instances: 1


### PR DESCRIPTION
Prototype of integration of `CloudFoundryPaasLocation` and `VanillaCloudFoundryApplication` entity. It is just a prototype, for example, driver pattern is not included yet, the envs are not supported yet and the artifact downloading is hardcoded instead of using `DownloaderResolver`. Some sensores and new effectors are necessary, to modify the hardware profile (such as memory or instances).

Next steps:
- Adding env support (very easy)
- Adding driver pattern
