### PR TITLE
Adding registry to manage the client.

### DIFF
--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryClientRegistry.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryClientRegistry.java
@@ -16,24 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.cloudfoundry.location.paas;
+package org.apache.brooklyn.cloudfoundry.location;
 
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.location.LocationConfigKeys;
-import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
-public interface PaasLocationConfig {
+import org.apache.brooklyn.util.core.config.ConfigBag;
 
-    @SetFromFlag("provider")
-    ConfigKey<String> CLOUD_PROVIDER = LocationConfigKeys.CLOUD_PROVIDER;
+public interface CloudFoundryClientRegistry {
 
-    @SetFromFlag("identity")
-    ConfigKey<String> ACCESS_IDENTITY = LocationConfigKeys.ACCESS_IDENTITY;
-
-    @SetFromFlag("credential")
-    ConfigKey<String> ACCESS_CREDENTIAL = LocationConfigKeys.ACCESS_CREDENTIAL;
-
-    @SetFromFlag("endpoint")
-    ConfigKey<String> CLOUD_ENDPOINT = LocationConfigKeys.CLOUD_ENDPOINT;
-
+    CloudFoundryPaasClient getCloudFoundryClient(ConfigBag conf, boolean allowReuse);
 }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasClientRegistryImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasClientRegistryImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.apache.brooklyn.cloudfoundry.location.paas.PaasLocationConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+
+
+public class CloudFoundryPaasClientRegistryImpl implements CloudFoundryClientRegistry {
+
+    public static final CloudFoundryPaasClientRegistryImpl INSTANCE = new CloudFoundryPaasClientRegistryImpl();
+
+    protected CloudFoundryPaasClientRegistryImpl() {
+    }
+
+    @Override
+    public CloudFoundryPaasClient getCloudFoundryClient(ConfigBag conf, boolean allowReuse) {
+        String username = checkNotNull(conf.get(PaasLocationConfig.ACCESS_IDENTITY), "identity must not be null");
+        String password = checkNotNull(conf.get(PaasLocationConfig.ACCESS_CREDENTIAL), "credential must not be null");
+        URL apiHost = getTargetURL(checkNotNull(conf.get(PaasLocationConfig.CLOUD_ENDPOINT), "endpoint must not be null"));
+        String organization = checkNotNull(conf.get(CloudFoundryPaasLocationConfig.CF_ORG), "organization must not be null");
+        String space = checkNotNull(conf.get(CloudFoundryPaasLocationConfig.CF_SPACE), "space must not be null");
+
+        CloudCredentials credentials = new CloudCredentials(username, password);
+        CloudFoundryClient client = new CloudFoundryClient(credentials, apiHost, organization, space, true);
+
+        client.login();
+
+        return getClougFoundryPaasClient(client);
+    }
+
+    private CloudFoundryPaasClient getClougFoundryPaasClient(CloudFoundryClient client) {
+        return new CloudFoundryPaasClient(client);
+    }
+
+    private static URL getTargetURL(String target) {
+        try {
+            return URI.create(target).toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("The target URL is not valid: " + e.getMessage());
+        }
+    }
+
+}
+

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -22,18 +22,25 @@ import java.util.Map;
 
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.location.paas.PaasLocation;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.config.ResolvingConfigBag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CloudFoundryPaasLocation extends AbstractLocation
-        implements PaasLocation, CloudFoundryPaasLocationConfig {
+public class CloudFoundryPaasLocation extends AbstractLocation implements PaasLocation, CloudFoundryPaasLocationConfig {
 
     public static final Logger log = LoggerFactory.getLogger(CloudFoundryPaasLocation.class);
 
     private CloudFoundryPaasClient client;
 
+
     public CloudFoundryPaasLocation() {
-        client = new CloudFoundryPaasClient(this);
+        super();
+    }
+
+    public CloudFoundryPaasLocation(Map<?, ?> properties) {
+        super(properties);
     }
 
     @Override
@@ -42,6 +49,22 @@ public class CloudFoundryPaasLocation extends AbstractLocation
     }
 
     protected CloudFoundryPaasClient getClient() {
+        return getClient(MutableMap.of());
+    }
+
+    protected CloudFoundryPaasClient getClient(Map<?, ?> flags) {
+        ConfigBag conf = (flags == null || flags.isEmpty())
+                ? config().getBag()
+                : ConfigBag.newInstanceExtending(config().getBag(), flags);
+        return getClient(conf);
+    }
+
+    protected CloudFoundryPaasClient getClient(ConfigBag config) {
+        if (client == null) {
+
+            CloudFoundryClientRegistry registry = getConfig(CF_CLIENT_REGISTRY);
+            client = registry.getCloudFoundryClient(ResolvingConfigBag.newInstanceExtending(getManagementContext(), config), true);
+        }
         return client;
     }
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
@@ -24,9 +24,14 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 
 public interface CloudFoundryPaasLocationConfig extends PaasLocationConfig {
 
-    public static ConfigKey<String> CF_ORG = ConfigKeys.newStringConfigKey("org",
+    ConfigKey<String> CF_ORG = ConfigKeys.newStringConfigKey("org",
             "Organization where paas resources will live.");
 
-    public static ConfigKey<String> CF_SPACE = ConfigKeys.newStringConfigKey("space",
+    ConfigKey<String> CF_SPACE = ConfigKeys.newStringConfigKey("space",
             "Space from the CloudFoundry services will be managed.");
+
+    ConfigKey<CloudFoundryClientRegistry> CF_CLIENT_REGISTRY = ConfigKeys.newConfigKey(
+            CloudFoundryClientRegistry.class, "cloudFoundryPaasClientRegistry",
+            "Registry/Factory for creating cloudfoundry client; default is almost always fine, " +
+                    "except where tests want to customize behaviour", CloudFoundryPaasClientRegistryImpl.INSTANCE);
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/AbstractCloudFoundryUnitTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/AbstractCloudFoundryUnitTest.java
@@ -34,7 +34,9 @@ public class AbstractCloudFoundryUnitTest extends BrooklynAppUnitTestSupport
         implements CloudFoundryTestFixtures {
 
     protected static final String APPLICATION_NAME = UUID.randomUUID().toString().substring(0, 8);
+
     protected static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
+
     protected static final String DEFAULT_APPLICATION_BROOKLYN_DOMAIN
             = APPLICATION_NAME + "." + BROOKLYN_DOMAIN;
     protected static final String DEFAULT_APPLICATION_ADDRESS

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/CloudFoundryTestFixtures.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/CloudFoundryTestFixtures.java
@@ -32,9 +32,7 @@ public interface CloudFoundryTestFixtures {
     public static final int CUSTOM_INSTANCES = INSTANCES * 2;
     public static final String APPLICATION_ARTIFACT =
             "brooklyn-example-hello-world-sql-webapp-in-paas.war";
-    public static final String APPLICATION_ARTIFACT_URL =
-            "classpath://" + APPLICATION_ARTIFACT;
-
+    public static final String APPLICATION_ARTIFACT_URL = "classpath://" + APPLICATION_ARTIFACT;
     public static final Map<String, String> EMPTY_ENV = MutableMap.of();
     public static final Map<String, String> SIMPLE_ENV = MutableMap.of("k1", "v1");
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.Map;
 
 import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
@@ -70,7 +71,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     }
 
     @Test
-    public void testStartApplication() {
+    public void testStartApplication() throws MalformedURLException {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
         doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(EMPTY_ENV);

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasClientLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasClientLiveTest.java
@@ -50,7 +50,9 @@ public class CloudFoundryPaasClientLiveTest extends AbstractCloudFoundryLiveTest
     @BeforeMethod
     public void setUp() throws Exception {
         super.setUp();
-        cloudFoundryPaasClient = new CloudFoundryPaasClient(cloudFoundryPaasLocation);
+        cloudFoundryPaasClient = cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_CLIENT_REGISTRY)
+                .getCloudFoundryClient(cloudFoundryPaasLocation.config().getBag(), false);
+
         applicationName = APPLICATION_NAME_PREFIX + UUID.randomUUID()
                 .toString().substring(0, 8);
         artifactLocalPath = getLocalPath(APPLICATION_ARTIFACT);
@@ -136,7 +138,7 @@ public class CloudFoundryPaasClientLiveTest extends AbstractCloudFoundryLiveTest
         assertFalse(Strings.isBlank(applicationUrl));
         startApplication(applicationName, applicationUrl);
 
-        cloudFoundryPaasClient.restart(applicationName);
+        cloudFoundryPaasClient.restartApplication(applicationName);
         checkDeployedApplicationAvailability(applicationName, applicationUrl);
 
         stopApplication(applicationName, applicationUrl);
@@ -214,5 +216,6 @@ public class CloudFoundryPaasClientLiveTest extends AbstractCloudFoundryLiveTest
             return "";
         }
     }
+
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationResolverTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -34,12 +33,13 @@ public class CloudFoundryPaasLocationResolverTest {
 
     private final String MY_PAAS_LOCATION = "my-cloudfoundry";
 
-    private final String IDENTITY = "user";
-    private final String CREDENTIAL = "password";
-    private final String ORG = "organization";
-    private final String SPACE = "space";
-    private final String ENDPOINT = "endpoint";
-    private final String ADDRESS = "run.provider.io";
+    private static final String PROVIDER = "provider";
+    private static final String IDENTITY = "user";
+    private static final String CREDENTIAL = "password";
+    private static final String ORG = "organization";
+    private static final String SPACE = "space";
+    private static final String ENDPOINT = "endpoint";
+    private static final String ADDRESS = "run.provider.io";
 
     @BeforeMethod
     public void setUp() {
@@ -47,6 +47,7 @@ public class CloudFoundryPaasLocationResolverTest {
         brooklynProperties = managementContext.getBrooklynProperties();
 
         brooklynProperties.put("brooklyn.location.named." + MY_PAAS_LOCATION, "cloudfoundry");
+        brooklynProperties.put("brooklyn.location.named." + MY_PAAS_LOCATION + ".provider", PROVIDER);
         brooklynProperties.put("brooklyn.location.named." + MY_PAAS_LOCATION + ".identity", IDENTITY);
         brooklynProperties.put("brooklyn.location.named." + MY_PAAS_LOCATION + ".credential", CREDENTIAL);
         brooklynProperties.put("brooklyn.location.named." + MY_PAAS_LOCATION + ".org", ORG);
@@ -64,16 +65,17 @@ public class CloudFoundryPaasLocationResolverTest {
 
     @Test
     public void testCloudFoundryTakesProvidersScopedProperties() {
-        ConfigBag config = resolve(MY_PAAS_LOCATION).config().getBag();
-        assertEquals(config.get(CloudFoundryPaasLocation.ACCESS_IDENTITY), IDENTITY);
-        assertEquals(config.get(CloudFoundryPaasLocation.ACCESS_CREDENTIAL), CREDENTIAL);
-        assertEquals(config.get(CloudFoundryPaasLocation.CLOUD_ENDPOINT), ENDPOINT);
-        assertEquals(config.get(CloudFoundryPaasLocation.CF_ORG), ORG);
-        assertEquals(config.get(CloudFoundryPaasLocation.CF_SPACE), SPACE);
+        CloudFoundryPaasLocation paasLocation = resolve(MY_PAAS_LOCATION);
+        assertEquals(paasLocation.getConfig(CloudFoundryPaasLocation.CLOUD_PROVIDER), PROVIDER);
+        assertEquals(paasLocation.getConfig(CloudFoundryPaasLocation.ACCESS_IDENTITY), IDENTITY);
+        assertEquals(paasLocation.getConfig(CloudFoundryPaasLocation.ACCESS_CREDENTIAL), CREDENTIAL);
+        assertEquals(paasLocation.getConfig(CloudFoundryPaasLocation.CLOUD_ENDPOINT), ENDPOINT);
+        assertEquals(paasLocation.getConfig(CloudFoundryPaasLocation.CF_ORG), ORG);
+        assertEquals(paasLocation.getConfig(CloudFoundryPaasLocation.CF_SPACE), SPACE);
     }
 
     private CloudFoundryPaasLocation resolve(String spec) {
-        return (CloudFoundryPaasLocation) managementContext.getLocationRegistry().resolve(spec);
+        return (CloudFoundryPaasLocation) managementContext.getLocationRegistry().getLocationManaged(spec);
     }
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClient.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClient.java
@@ -1,0 +1,766 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.text.Strings;
+import org.cloudfoundry.client.lib.ApplicationLogListener;
+import org.cloudfoundry.client.lib.ClientHttpResponseCallback;
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudFoundryException;
+import org.cloudfoundry.client.lib.CloudFoundryOperations;
+import org.cloudfoundry.client.lib.RestLogCallback;
+import org.cloudfoundry.client.lib.StartingInfo;
+import org.cloudfoundry.client.lib.StreamingLogToken;
+import org.cloudfoundry.client.lib.UploadStatusCallback;
+import org.cloudfoundry.client.lib.archive.ApplicationArchive;
+import org.cloudfoundry.client.lib.domain.ApplicationLog;
+import org.cloudfoundry.client.lib.domain.ApplicationStats;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudDomain;
+import org.cloudfoundry.client.lib.domain.CloudEvent;
+import org.cloudfoundry.client.lib.domain.CloudInfo;
+import org.cloudfoundry.client.lib.domain.CloudOrganization;
+import org.cloudfoundry.client.lib.domain.CloudQuota;
+import org.cloudfoundry.client.lib.domain.CloudRoute;
+import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
+import org.cloudfoundry.client.lib.domain.CloudService;
+import org.cloudfoundry.client.lib.domain.CloudServiceBroker;
+import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
+import org.cloudfoundry.client.lib.domain.CloudServiceOffering;
+import org.cloudfoundry.client.lib.domain.CloudSpace;
+import org.cloudfoundry.client.lib.domain.CloudStack;
+import org.cloudfoundry.client.lib.domain.CloudUser;
+import org.cloudfoundry.client.lib.domain.CrashesInfo;
+import org.cloudfoundry.client.lib.domain.InstancesInfo;
+import org.cloudfoundry.client.lib.domain.Staging;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import com.squareup.okhttp.mockwebserver.Dispatcher;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+
+public class FakeCloudFoundryClient implements CloudFoundryOperations {
+
+    private static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
+
+    private Map<String, CloudApplication> applications;
+
+    public FakeCloudFoundryClient() {
+        applications = MutableMap.of();
+    }
+
+    @Override
+    public void createApplication(String appName, Staging staging, Integer disk, Integer memory, List<String> uris, List<String> serviceNames) {
+        createApplication(appName, staging, memory, uris, serviceNames);
+        applications.get(appName).setDiskQuota(disk);
+    }
+
+    @Override
+    public void createApplication(String appName, Staging staging, Integer memory, List<String> uris, List<String> serviceNames) {
+        CloudApplication app = new CloudApplication(appName, null, null, memory, 1, uris, serviceNames, CloudApplication.AppState.STOPPED);
+        applications.put(appName, app);
+    }
+
+    @Override
+    public CloudApplication getApplication(String appName) {
+        CloudApplication application = applications.get(appName);
+        if (application == null) {
+            throw new CloudFoundryException(HttpStatus.NOT_FOUND);
+        }
+        return application;
+    }
+
+    @Override
+    public void uploadApplication(String appName, String file) throws IOException {
+        if (!Files.exists(Paths.get(file))) {
+            throw new FileNotFoundException("File :" + file + " was not found by " + this);
+        }
+    }
+
+    @Override
+    public void uploadApplication(String appName, File file) throws IOException {
+        //nothing
+    }
+
+    @Override
+    public void uploadApplication(String appName, File file, UploadStatusCallback callback) throws IOException {
+        //nothing
+    }
+
+    @Override
+    public void uploadApplication(String appName, String fileName, InputStream inputStream) throws IOException {
+        //nothing
+    }
+
+    @Override
+    public void uploadApplication(String appName, String fileName, InputStream inputStream, UploadStatusCallback callback) throws IOException {
+        //nothing
+    }
+
+    @Override
+    public void uploadApplication(String appName, ApplicationArchive archive) throws IOException {
+        //nothing
+    }
+
+    @Override
+    public void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException {
+        //nothing
+    }
+
+    @Override
+    public StartingInfo startApplication(String appName) {
+        CloudApplication application = getApplication(appName);
+        application.setState(CloudApplication.AppState.STARTED);
+        return new StartingInfo(Strings.EMPTY);
+    }
+
+    @Override
+    public void debugApplication(String appName, CloudApplication.DebugMode mode) {
+
+    }
+
+    @Override
+    public void stopApplication(String appName) {
+        CloudApplication application = getApplication(appName);
+        application.setState(CloudApplication.AppState.STOPPED);
+    }
+
+    @Override
+    public StartingInfo restartApplication(String appName) {
+        return startApplication(appName);
+    }
+
+    @Override
+    public void deleteApplication(String appName) {
+        CloudApplication application = getApplication(appName);
+        applications.remove(appName);
+    }
+
+    @Override
+    public void deleteAllApplications() {
+
+    }
+
+    @Override
+    public void deleteAllServices() {
+
+    }
+
+    @Override
+    public void updateApplicationDiskQuota(String appName, int disk) {
+        CloudApplication application = getApplication(appName);
+        application.setDiskQuota(disk);
+    }
+
+    @Override
+    public void updateApplicationMemory(String appName, int memory) {
+        CloudApplication application = getApplication(appName);
+        application.setMemory(memory);
+    }
+
+    @Override
+    public void updateApplicationInstances(String appName, int instances) {
+        CloudApplication application = getApplication(appName);
+        application.setInstances(instances);
+    }
+
+    @Override
+    public void updateApplicationServices(String appName, List<String> services) {
+
+    }
+
+    @Override
+    public void updateApplicationStaging(String appName, Staging staging) {
+
+    }
+
+    @Override
+    public void updateApplicationUris(String appName, List<String> uris) {
+
+    }
+
+    @Override
+    public void updateApplicationEnv(String appName, Map<String, String> env) {
+        Map<Object, Object> newEnv = MutableMap.of();
+        newEnv.putAll(env);
+        getApplication(appName).setEnv(newEnv);
+    }
+
+    @Override
+    public void setResponseErrorHandler(ResponseErrorHandler errorHandler) {
+
+    }
+
+    @Override
+    public URL getCloudControllerUrl() {
+        return null;
+    }
+
+    @Override
+    public CloudInfo getCloudInfo() {
+        return null;
+    }
+
+    @Override
+    public List<CloudSpace> getSpaces() {
+        return null;
+    }
+
+    @Override
+    public List<UUID> getSpaceManagers(String spaceName) {
+        return null;
+    }
+
+    @Override
+    public List<UUID> getSpaceDevelopers(String spaceName) {
+        return null;
+    }
+
+    @Override
+    public List<UUID> getSpaceAuditors(String spaceName) {
+        return null;
+    }
+
+    @Override
+    public List<UUID> getSpaceManagers(String orgName, String spaceName) {
+        return null;
+    }
+
+    @Override
+    public List<UUID> getSpaceDevelopers(String orgName, String spaceName) {
+        return null;
+    }
+
+    @Override
+    public List<UUID> getSpaceAuditors(String orgName, String spaceName) {
+        return null;
+    }
+
+    @Override
+    public void associateAuditorWithSpace(String spaceName) {
+
+    }
+
+    @Override
+    public void associateDeveloperWithSpace(String spaceName) {
+
+    }
+
+    @Override
+    public void associateManagerWithSpace(String spaceName) {
+
+    }
+
+    @Override
+    public void associateAuditorWithSpace(String orgName, String spaceName) {
+
+    }
+
+    @Override
+    public void associateDeveloperWithSpace(String orgName, String spaceName) {
+
+    }
+
+    @Override
+    public void associateManagerWithSpace(String orgName, String spaceName) {
+
+    }
+
+    @Override
+    public void associateAuditorWithSpace(String orgName, String spaceName, String userGuid) {
+
+    }
+
+    @Override
+    public void associateDeveloperWithSpace(String orgName, String spaceName, String userGuid) {
+
+    }
+
+    @Override
+    public void associateManagerWithSpace(String orgName, String spaceName, String userGuid) {
+
+    }
+
+    @Override
+    public void createSpace(String spaceName) {
+
+    }
+
+    @Override
+    public CloudSpace getSpace(String spaceName) {
+        return null;
+    }
+
+    @Override
+    public void deleteSpace(String spaceName) {
+
+    }
+
+    @Override
+    public List<CloudOrganization> getOrganizations() {
+        return null;
+    }
+
+    @Override
+    public CloudOrganization getOrgByName(String orgName, boolean required) {
+        return null;
+    }
+
+    @Override
+    public void register(String email, String password) {
+
+    }
+
+    @Override
+    public void updatePassword(String newPassword) {
+
+    }
+
+    @Override
+    public void updatePassword(CloudCredentials credentials, String newPassword) {
+
+    }
+
+    @Override
+    public void unregister() {
+
+    }
+
+    @Override
+    public OAuth2AccessToken login() {
+        return null;
+    }
+
+    @Override
+    public void logout() {
+
+    }
+
+    @Override
+    public List<CloudApplication> getApplications() {
+        return null;
+    }
+
+    @Override
+    public CloudApplication getApplication(UUID guid) {
+        return null;
+    }
+
+    @Override
+    public ApplicationStats getApplicationStats(String appName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getApplicationEnvironment(String appName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getApplicationEnvironment(UUID appGuid) {
+        return null;
+    }
+
+    @Override
+    public void createService(CloudService service) {
+
+    }
+
+    @Override
+    public void createUserProvidedService(CloudService service, Map<String, Object> credentials) {
+
+    }
+
+    @Override
+    public void createUserProvidedService(CloudService service, Map<String, Object> credentials, String syslogDrainUrl) {
+
+    }
+
+    @Override
+    public List<CloudRoute> deleteOrphanedRoutes() {
+        return null;
+    }
+
+    @Override
+    public void updateApplicationEnv(String appName, List<String> env) {
+
+    }
+
+    @Override
+    public List<CloudEvent> getEvents() {
+        return null;
+    }
+
+    @Override
+    public List<CloudEvent> getApplicationEvents(String appName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getLogs(String appName) {
+        return null;
+    }
+
+    @Override
+    public StreamingLogToken streamLogs(String appName, ApplicationLogListener listener) {
+        return null;
+    }
+
+    @Override
+    public List<ApplicationLog> getRecentLogs(String appName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getCrashLogs(String appName) {
+        return null;
+    }
+
+    @Override
+    public String getStagingLogs(StartingInfo info, int offset) {
+        return null;
+    }
+
+    @Override
+    public List<CloudStack> getStacks() {
+        return null;
+    }
+
+    @Override
+    public CloudStack getStack(String name) {
+        return null;
+    }
+
+    @Override
+    public String getFile(String appName, int instanceIndex, String filePath) {
+        return null;
+    }
+
+    @Override
+    public String getFile(String appName, int instanceIndex, String filePath, int startPosition) {
+        return null;
+    }
+
+    @Override
+    public String getFile(String appName, int instanceIndex, String filePath, int startPosition, int endPosition) {
+        return null;
+    }
+
+    @Override
+    public String getFileTail(String appName, int instanceIndex, String filePath, int length) {
+        return null;
+    }
+
+    @Override
+    public void openFile(String appName, int instanceIndex, String filePath, ClientHttpResponseCallback clientHttpResponseCallback) {
+
+    }
+
+    @Override
+    public List<CloudService> getServices() {
+        return null;
+    }
+
+    @Override
+    public CloudService getService(String service) {
+        return null;
+    }
+
+    @Override
+    public CloudServiceInstance getServiceInstance(String service) {
+        return null;
+    }
+
+    @Override
+    public void deleteService(String service) {
+
+    }
+
+    @Override
+    public List<CloudServiceOffering> getServiceOfferings() {
+        return null;
+    }
+
+    @Override
+    public List<CloudServiceBroker> getServiceBrokers() {
+        return null;
+    }
+
+    @Override
+    public CloudServiceBroker getServiceBroker(String name) {
+        return null;
+    }
+
+    @Override
+    public void createServiceBroker(CloudServiceBroker serviceBroker) {
+
+    }
+
+    @Override
+    public void updateServiceBroker(CloudServiceBroker serviceBroker) {
+
+    }
+
+    @Override
+    public void deleteServiceBroker(String name) {
+
+    }
+
+    @Override
+    public void updateServicePlanVisibilityForBroker(String name, boolean visibility) {
+
+    }
+
+    @Override
+    public void bindService(String appName, String serviceName) {
+
+    }
+
+    @Override
+    public void unbindService(String appName, String serviceName) {
+
+    }
+
+    @Override
+    public InstancesInfo getApplicationInstances(String appName) {
+        return null;
+    }
+
+    @Override
+    public InstancesInfo getApplicationInstances(CloudApplication app) {
+        return null;
+    }
+
+    @Override
+    public CrashesInfo getCrashes(String appName) {
+        return null;
+    }
+
+    @Override
+    public void rename(String appName, String newName) {
+
+    }
+
+    @Override
+    public List<CloudDomain> getDomainsForOrg() {
+        return null;
+    }
+
+    @Override
+    public List<CloudDomain> getPrivateDomains() {
+        return null;
+    }
+
+    @Override
+    public List<CloudDomain> getSharedDomains() {
+        return MutableList.of(new CloudDomain(null, BROOKLYN_DOMAIN, null));
+    }
+
+    @Override
+    public List<CloudDomain> getDomains() {
+        return MutableList.of(new CloudDomain(null, BROOKLYN_DOMAIN, null));
+    }
+
+    @Override
+    public CloudDomain getDefaultDomain() {
+        return new CloudDomain(null, BROOKLYN_DOMAIN, null);
+    }
+
+    @Override
+    public void addDomain(String domainName) {
+
+    }
+
+    @Override
+    public void removeDomain(String domainName) {
+
+    }
+
+    @Override
+    public void deleteDomain(String domainName) {
+
+    }
+
+    @Override
+    public List<CloudRoute> getRoutes(String domainName) {
+        return null;
+    }
+
+    @Override
+    public void addRoute(String host, String domainName) {
+
+    }
+
+    @Override
+    public void deleteRoute(String host, String domainName) {
+
+    }
+
+    @Override
+    public void registerRestLogListener(RestLogCallback callBack) {
+
+    }
+
+    @Override
+    public void unRegisterRestLogListener(RestLogCallback callBack) {
+
+    }
+
+    @Override
+    public CloudQuota getQuotaByName(String quotaName, boolean required) {
+        return null;
+    }
+
+    @Override
+    public void setQuotaToOrg(String orgName, String quotaName) {
+
+    }
+
+    @Override
+    public void createQuota(CloudQuota quota) {
+
+    }
+
+    @Override
+    public void deleteQuota(String quotaName) {
+
+    }
+
+    @Override
+    public List<CloudQuota> getQuotas() {
+        return null;
+    }
+
+    @Override
+    public void updateQuota(CloudQuota quota, String name) {
+
+    }
+
+    @Override
+    public List<CloudSecurityGroup> getSecurityGroups() {
+        return null;
+    }
+
+    @Override
+    public CloudSecurityGroup getSecurityGroup(String securityGroupName) {
+        return null;
+    }
+
+    @Override
+    public void createSecurityGroup(CloudSecurityGroup securityGroup) {
+
+    }
+
+    @Override
+    public void createSecurityGroup(String name, InputStream jsonRulesFile) {
+
+    }
+
+    @Override
+    public void updateSecurityGroup(CloudSecurityGroup securityGroup) {
+
+    }
+
+    @Override
+    public void updateSecurityGroup(String name, InputStream jsonRulesFile) {
+
+    }
+
+    @Override
+    public void deleteSecurityGroup(String securityGroupName) {
+
+    }
+
+    @Override
+    public List<CloudSecurityGroup> getStagingSecurityGroups() {
+        return null;
+    }
+
+    @Override
+    public void bindStagingSecurityGroup(String securityGroupName) {
+
+    }
+
+    @Override
+    public void unbindStagingSecurityGroup(String securityGroupName) {
+
+    }
+
+    @Override
+    public List<CloudSecurityGroup> getRunningSecurityGroups() {
+        return null;
+    }
+
+    @Override
+    public void bindRunningSecurityGroup(String securityGroupName) {
+
+    }
+
+    @Override
+    public void unbindRunningSecurityGroup(String securityGroupName) {
+
+    }
+
+    @Override
+    public List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName) {
+        return null;
+    }
+
+    @Override
+    public void bindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
+
+    }
+
+    @Override
+    public void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
+
+    }
+
+    @Override
+    public Map<String, CloudUser> getOrganizationUsers(String orgName) {
+        return null;
+    }
+
+    private Dispatcher getGenericDispatcher() {
+        return new Dispatcher() {
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                if (request.getPath().equals("/")) {
+                    return new MockResponse().setResponseCode(200);
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+    }
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/StubbedCloudFoundryPaasClientRegistry.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/StubbedCloudFoundryPaasClientRegistry.java
@@ -16,24 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.cloudfoundry.location.paas;
+package org.apache.brooklyn.cloudfoundry.location;
 
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.location.LocationConfigKeys;
-import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 
-public interface PaasLocationConfig {
+public class StubbedCloudFoundryPaasClientRegistry implements CloudFoundryClientRegistry {
 
-    @SetFromFlag("provider")
-    ConfigKey<String> CLOUD_PROVIDER = LocationConfigKeys.CLOUD_PROVIDER;
-
-    @SetFromFlag("identity")
-    ConfigKey<String> ACCESS_IDENTITY = LocationConfigKeys.ACCESS_IDENTITY;
-
-    @SetFromFlag("credential")
-    ConfigKey<String> ACCESS_CREDENTIAL = LocationConfigKeys.ACCESS_CREDENTIAL;
-
-    @SetFromFlag("endpoint")
-    ConfigKey<String> CLOUD_ENDPOINT = LocationConfigKeys.CLOUD_ENDPOINT;
-
+    @Override
+    public CloudFoundryPaasClient getCloudFoundryClient(ConfigBag conf, boolean allowReuse) {
+        return new CloudFoundryPaasClient(new FakeCloudFoundryClient());
+    }
 }


### PR DESCRIPTION
Adding a `CloudFoundryRegistry` to mock the `CloudFoundryOperations`.
A FakeCloudFoundryClient is added which mocks the CloudFoundryOperations.

A Registry which allows `CloudFoundryPaasLocation` to delegate the client creation.
The next step is to avoid a `CloudFoundryPaasClient` and to move its code to `CloudFoundryPaasLocation`.

This PR is based on the @andreaturli suggestions (in #9 and #10 ). 
