### PR TITLE
Integrations tests

### DIFF
--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriver.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriver.java
@@ -81,7 +81,6 @@ public class VanillaPaasApplicationCloudFoundryDriver implements VanillaPaasAppl
         Map<String, Object> params = MutableMap.copyOf(entity.config().getBag().getAllConfig());
         params.put(VanillaCloudFoundryApplication.APPLICATION_NAME.getName(), applicationName);
 
-
         if (!Strings.isBlank(entity.getConfig(VanillaCloudFoundryApplication.ARTIFACT_PATH))) {
             params.put(VanillaCloudFoundryApplication.ARTIFACT_PATH.getName(), getLocalPath());
         }

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -144,9 +144,17 @@ public class CloudFoundryPaasLocation extends AbstractLocation implements PaasLo
         String domainUri = null;
         Optional<CloudApplication> optional = getApplication(applicationName);
         if (optional.isPresent()) {
-            domainUri = "https://" + optional.get().getUris().get(0);
+            domainUri = composeApplicationUri(optional.get().getUris().get(0));
         }
         return domainUri;
+    }
+
+    private String composeApplicationUri(String baseApplicationDomain) {
+        if ((!baseApplicationDomain.startsWith("https://"))
+                && (!baseApplicationDomain.startsWith("http://"))) {
+            baseApplicationDomain = "https://" + baseApplicationDomain;
+        }
+        return baseApplicationDomain;
     }
 
     private Optional<CloudApplication> getApplication(String applicationName) {

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverIntegrationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverIntegrationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.entity;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Map;
+
+import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
+import org.apache.brooklyn.cloudfoundry.location.FakeCloudFoundryClient;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class VanillaPaasApplicationCloudFoundryDriverIntegrationTest extends AbstractCloudFoundryUnitTest {
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
+        cloudFoundryPaasLocation = createCloudFoundryPaasLocation(true);
+    }
+
+    @Test
+    public void testStartApplication() throws MalformedURLException {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        testSensorInitialization(entity);
+        assertTrue(driver.isRunning());
+        assertTrue(EMPTY_ENV.isEmpty());
+    }
+
+    @Test
+    public void testStartApplicationWithEnv() {
+        VanillaCloudFoundryApplicationImpl entity = createEntity(SIMPLE_ENV);
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+        testSensorInitialization(entity);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ENV), SIMPLE_ENV);
+    }
+
+    @Test
+    public void testSetEnvToApplication() {
+        Map<String, String> env = MutableMap.copyOf(SIMPLE_ENV);
+        VanillaCloudFoundryApplicationImpl entity = createEntity(SIMPLE_ENV);
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ENV), env);
+        assertTrue(driver.isRunning());
+
+        Map<String, String> newEnv = MutableMap.of("k2", "v2");
+        driver.setEnv(newEnv);
+        env.putAll(newEnv);
+        entity.getAttribute(VanillaCloudFoundryApplication.ENV);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ENV), env);
+    }
+
+    @Test
+    @SuppressWarnings("all")
+    public void testSetNullEnvToApplication() {
+        Map<String, String> newEnv = null;
+        VanillaCloudFoundryApplicationImpl entity = createEntity(SIMPLE_ENV);
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        driver.setEnv(newEnv);
+        assertEquals(entity
+                .getAttribute(VanillaCloudFoundryApplication.ENV), SIMPLE_ENV);
+        assertTrue(driver.isRunning());
+    }
+
+    @Test
+    public void testSetMemory() {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+        checkDefaultResourceProfile(entity);
+
+        driver.setMemory(CUSTOM_MEMORY);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY).intValue(),
+                CUSTOM_MEMORY);
+    }
+
+    @Test
+    public void testSetDisk() {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+        checkDefaultResourceProfile(entity);
+
+        driver.setDiskQuota(CUSTOM_DISK);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK).intValue(),
+                CUSTOM_DISK);
+    }
+
+    @Test
+    public void testSetInstances() {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+        checkDefaultResourceProfile(entity);
+
+        driver.setInstancesNumber(CUSTOM_INSTANCES);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
+                CUSTOM_INSTANCES);
+    }
+
+    @Test
+    public void testStopApplication() throws IOException {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+
+        driver.stop();
+        assertFalse(driver.isRunning());
+    }
+
+    @Test
+    public void testRestartApplication() {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+
+        driver.restart();
+    }
+
+    @Test
+    public void testDeleteApplication() throws IOException {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        VanillaPaasApplicationDriver driver =
+                new VanillaPaasApplicationCloudFoundryDriver(entity, cloudFoundryPaasLocation);
+        driver.start();
+        assertTrue(driver.isRunning());
+        driver.delete();
+        assertFalse(driver.isRunning());
+    }
+
+    private VanillaCloudFoundryApplicationImpl createEntity() {
+        VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_LOCAL_PATH);
+        entity.setManagementContext(mgmt);
+        return entity;
+    }
+
+    private VanillaCloudFoundryApplicationImpl createEntity(Map<String, String> env) {
+        VanillaCloudFoundryApplicationImpl entity = createEntity();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ENV, env);
+        return entity;
+    }
+
+    private void testSensorInitialization(VanillaCloudFoundryApplicationImpl entity) {
+        String appPath = applicationPathFromName(entity.getApplicationName());
+        assertTrue(entity.getAttribute(Attributes.MAIN_URI).toString().endsWith(appPath));
+        assertTrue(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL).endsWith(appPath));
+        checkDefaultResourceProfile(entity);
+    }
+
+    private String applicationPathFromName(String applicationName) {
+        return applicationName + "." + FakeCloudFoundryClient.BROOKLYN_DOMAIN;
+    }
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -46,10 +46,6 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
 
     private CloudFoundryOperations client;
 
-    @SuppressWarnings("all")
-    public final String APPLICATION_LOCAL_PATH = getClass()
-            .getClassLoader().getResource(APPLICATION_ARTIFACT).getPath();
-
     @BeforeMethod
     public void setUp() throws Exception {
         super.setUp();

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClient.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClient.java
@@ -73,7 +73,7 @@ import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 public class FakeCloudFoundryClient implements CloudFoundryOperations {
 
-    private static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
+    public static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
 
     private Map<String, CloudApplication> applications;
 
@@ -164,7 +164,9 @@ public class FakeCloudFoundryClient implements CloudFoundryOperations {
 
     @Override
     public void deleteApplication(String appName) {
-        applications.remove(appName);
+        if (getApplication(appName) != null) {
+            applications.remove(appName);
+        }
     }
 
     @Override

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClientWithServer.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClientWithServer.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.util.collections.MutableList;
+import org.cloudfoundry.client.lib.CloudFoundryOperations;
+import org.cloudfoundry.client.lib.StartingInfo;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.CloudUser;
+import org.cloudfoundry.client.lib.domain.Staging;
+
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.mockwebserver.Dispatcher;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+
+public class FakeCloudFoundryClientWithServer extends FakeCloudFoundryClient
+        implements CloudFoundryOperations {
+
+    private MockWebServer mockWebServer;
+    private HttpUrl serverUrl;
+    private String applicationBaseUrl;
+
+    public FakeCloudFoundryClientWithServer() {
+        super();
+        mockWebServer = new MockWebServer();
+        serverUrl = mockWebServer.url("/");
+        applicationBaseUrl = serverUrl.url().toString();
+    }
+
+    @Override
+    public void createApplication(String appName, Staging staging, Integer disk, Integer memory, List<String> uris, List<String> serviceNames) {
+        this.createApplication(appName, staging, memory, uris, serviceNames);
+        updateApplicationDiskQuota(appName, disk);
+    }
+
+    @Override
+    public void createApplication(String appName, Staging staging, Integer memory, List<String> uris, List<String> serviceNames) {
+        if ((uris == null) || (uris.size() != 1)) {
+            throw new IllegalStateException("The application " + appName + " requieres at least " +
+                    "an uri to be deployed");
+        }
+        String applicationPath = getApplicationUrl(uris.get(0));
+        super.createApplication(appName, staging, memory, MutableList.of(applicationPath), serviceNames);
+    }
+
+    private String getApplicationUrl(String applicationName) {
+        return applicationBaseUrl + applicationName;
+    }
+
+    private String getApplicationPathFromUrl(String applicationUrl) {
+        return applicationUrl.replace(applicationBaseUrl, "");
+    }
+
+    @Override
+    public StartingInfo startApplication(String appName) {
+        CloudApplication application = getApplication(appName);
+        String applicationPath = getApplicationPathFromUrl(application.getUris().get(0));
+        mockWebServer.setDispatcher(enableApplicationDispatcher(applicationPath));
+        return super.startApplication(appName);
+    }
+
+    @Override
+    public void stopApplication(String appName) {
+        CloudApplication application = getApplication(appName);
+        String applicationPath = getApplicationPathFromUrl(application.getUris().get(0));
+        mockWebServer.setDispatcher(disblaeApplicationDispatcher(applicationPath));
+        super.stopApplication(appName);
+    }
+
+    @Override
+    public Map<String, CloudUser> getOrganizationUsers(String orgName) {
+        return null;
+    }
+
+    private Dispatcher enableApplicationDispatcher(final String applicationDomain) {
+        return new Dispatcher() {
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                if (request.getPath().equals("/" + applicationDomain)) {
+                    return new MockResponse().setResponseCode(200);
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+    }
+
+    private Dispatcher disblaeApplicationDispatcher(final String applicationDomain) {
+        return new Dispatcher() {
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                if (request.getPath().equals("/" + applicationDomain)) {
+                    return new MockResponse().setResponseCode(404);
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+    }
+
+    @Override
+    public void deleteApplication(String appName) {
+        stopApplication(appName);
+        super.deleteApplication(appName);
+    }
+
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/StubbedCloudFoundryClientWitServerRegistry.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/StubbedCloudFoundryClientWitServerRegistry.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import static org.mockito.Mockito.spy;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.cloudfoundry.client.lib.CloudFoundryOperations;
+
+public class StubbedCloudFoundryClientWitServerRegistry implements CloudFoundryClientRegistry {
+
+    @Override
+    public CloudFoundryOperations getCloudFoundryClient(ConfigBag conf, boolean allowReuse) {
+        return spy(new FakeCloudFoundryClientWithServer());
+    }
+}


### PR DESCRIPTION
Integrations test for the driver.

It looks that `cf-driver` needs a integration test in order to check how the it manage the location. `FakeCloudFoundryClient` is extended by `FakeCloudFoundryClientWithServer`. This new fake-client allows to check if the application url is available according to the application status, for example when application is `STOPPED` the `driver` expects that the application url returns an 404. 
