### PR TITLE
Updating cf client version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@
 #
 language: java
 jdk:
-- oraclejdk7
+- oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
 
     <properties>
         <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version>
-        <!-- TODO updating to Snapshot -->
-        <cloudfoundry.client.version>1.1.3</cloudfoundry.client.version>
+        <cloudfoundry.client.version>2.0.0.BUILD-SNAPSHOT</cloudfoundry.client.version>
+        <reactor.core.version>3.0.0.RC1</reactor.core.version>
+        <reactor.netty.version>0.5.0.BUILD-SNAPSHOT</reactor.netty.version>
         <mockito.version>1.10.19</mockito.version>
         <mockwebserver.version>2.7.0</mockwebserver.version>
     </properties>
@@ -46,6 +47,22 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
+    <repositories>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>http://repo.spring.io/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>http://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -58,6 +75,20 @@
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-core</artifactId>
             <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -68,8 +99,24 @@
 
         <dependency>
             <groupId>org.cloudfoundry</groupId>
-            <artifactId>cloudfoundry-client-lib</artifactId>
+            <artifactId>cloudfoundry-client-reactor</artifactId>
             <version>${cloudfoundry.client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.cloudfoundry</groupId>
+            <artifactId>cloudfoundry-operations</artifactId>
+            <version>${cloudfoundry.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${reactor.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor.ipc</groupId>
+            <artifactId>reactor-netty</artifactId>
+            <version>${reactor.netty.version}</version>
         </dependency>
 
         <dependency>
@@ -95,10 +142,32 @@
 
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-launcher</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-core</artifactId>
             <version>${brooklyn.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version>
+        <java.version>1.8</java.version>
         <cloudfoundry.client.version>2.0.0.BUILD-SNAPSHOT</cloudfoundry.client.version>
         <reactor.core.version>3.0.0.RC1</reactor.core.version>
         <reactor.netty.version>0.5.0.BUILD-SNAPSHOT</reactor.netty.version>

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplication.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 
 @Catalog(name = "Vanilla CloudFoundry Application entity")
@@ -64,7 +65,7 @@ public interface VanillaCloudFoundryApplication extends Entity, Startable, Drive
 
     @SetFromFlag("domain")
     ConfigKey<String> APPLICATION_DOMAIN = ConfigKeys.newStringConfigKey(
-            "cloudFoundry.application.domain", "Domain for the application");
+            "cloudFoundry.application.domain", "Domain for the application", Strings.EMPTY);
 
     @SetFromFlag("host")
     ConfigKey<String> APPLICATION_HOST = ConfigKeys.newStringConfigKey(

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplication.java
@@ -43,9 +43,10 @@ import org.apache.brooklyn.util.time.Duration;
 @ImplementedBy(VanillaCloudFoundryApplicationImpl.class)
 public interface VanillaCloudFoundryApplication extends Entity, Startable, DriverDependentEntity {
 
-    @SetFromFlag("name")
-    ConfigKey<String> APPLICATION_NAME = ConfigKeys.newStringConfigKey(
-            "cloudFoundry.application.name", "Name of the application");
+    @SetFromFlag("name-app")
+    BasicAttributeSensorAndConfigKey<String> APPLICATION_NAME =
+            new BasicAttributeSensorAndConfigKey<String>(String.class,
+                    "cloudFoundry.application.name", "Name of the application");
 
     @SetFromFlag("path")
     ConfigKey<String> ARTIFACT_PATH = ConfigKeys.newStringConfigKey(
@@ -67,7 +68,8 @@ public interface VanillaCloudFoundryApplication extends Entity, Startable, Drive
 
     @SetFromFlag("host")
     ConfigKey<String> APPLICATION_HOST = ConfigKeys.newStringConfigKey(
-            "cloudFoundry.application.host", "Host or sub-domain for the application");
+            "cloudFoundry.application.host", "Host or sub-domain for the application, if " +
+                    "this value is empty the application name will be used like the host");
 
     @SetFromFlag("instances")
     ConfigKey<Integer> REQUIRED_INSTANCES = ConfigKeys.newIntegerConfigKey(
@@ -77,7 +79,7 @@ public interface VanillaCloudFoundryApplication extends Entity, Startable, Drive
     ConfigKey<Integer> REQUIRED_MEMORY = ConfigKeys.newIntegerConfigKey(
             "cloudfoundry.profile.memory", "Memory allocated for the application (MB)", 512);
 
-    @SetFromFlag("disk")
+    @SetFromFlag("disk_quota")
     ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
             "cloudfoundry.profile.disk", "Disk size allocated for the application (MB)", 1024);
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplication.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplication.java
@@ -43,7 +43,7 @@ import org.apache.brooklyn.util.time.Duration;
 @ImplementedBy(VanillaCloudFoundryApplicationImpl.class)
 public interface VanillaCloudFoundryApplication extends Entity, Startable, DriverDependentEntity {
 
-    @SetFromFlag("name-app")
+    @SetFromFlag("nameApp")
     BasicAttributeSensorAndConfigKey<String> APPLICATION_NAME =
             new BasicAttributeSensorAndConfigKey<String>(String.class,
                     "cloudFoundry.application.name", "Name of the application");

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.cloudfoundry.entity;
 
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -348,7 +349,7 @@ public class VanillaCloudFoundryApplicationImpl extends AbstractEntity implement
         if (driver != null) {
             if ((driver instanceof VanillaPaasApplicationCloudFoundryDriver)
                     && location.equals((driver).getLocation())) {
-                return driver; //just reuse
+                return driver;
             } else {
                 log.warn("driver/location change is untested for {} at {}; changing driver and continuing", this, location);
                 return newDriver(location);

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationImpl.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationImpl.java
@@ -92,6 +92,7 @@ public class VanillaCloudFoundryApplicationImpl extends AbstractEntity implement
         if (Strings.isBlank(applicationName)) {
             applicationName = DEFAULT_APP_PREFIX + Identifiers.makeRandomId(8);
         }
+        this.sensors().set(APPLICATION_NAME, applicationName);
     }
 
     @Override

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriver.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriver.java
@@ -50,7 +50,7 @@ public class VanillaPaasApplicationCloudFoundryDriver implements VanillaPaasAppl
     private VanillaCloudFoundryApplicationImpl entity;
     private String applicationName;
     private String applicationUrl;
-    protected String localPathArtifact;
+    protected String localArtifactPath;
 
     public VanillaPaasApplicationCloudFoundryDriver(VanillaCloudFoundryApplicationImpl entity,
                                                     CloudFoundryPaasLocation location) {
@@ -81,8 +81,8 @@ public class VanillaPaasApplicationCloudFoundryDriver implements VanillaPaasAppl
         Map<String, Object> params = MutableMap.copyOf(entity.config().getBag().getAllConfig());
         params.put(VanillaCloudFoundryApplication.APPLICATION_NAME.getName(), applicationName);
         String artifactPath = entity.getConfig(VanillaCloudFoundryApplication.ARTIFACT_PATH);
-        localPathArtifact = getLocalPath(artifactPath);
-        params.put(VanillaCloudFoundryApplication.ARTIFACT_PATH.getName(), localPathArtifact);
+        localArtifactPath = getLocalPath(artifactPath);
+        params.put(VanillaCloudFoundryApplication.ARTIFACT_PATH.getName(), localArtifactPath);
 
         applicationUrl = location.deploy(params);
         return applicationUrl;
@@ -167,19 +167,19 @@ public class VanillaPaasApplicationCloudFoundryDriver implements VanillaPaasAppl
 
     @Override
     public void setMemory(int memory) {
-        location.setMemory(applicationName, memory, localPathArtifact);
+        location.setMemory(applicationName, memory, localArtifactPath);
         updateMemorySensor(location.getMemory(applicationName));
     }
 
     @Override
     public void setDiskQuota(int diskQuota) {
-        location.setDiskQuota(applicationName, diskQuota, localPathArtifact);
+        location.setDiskQuota(applicationName, diskQuota, localArtifactPath);
         updateDiskSensor(location.getDiskQuota(applicationName));
     }
 
     @Override
     public void setInstancesNumber(int instances) {
-        location.setInstancesNumber(applicationName, instances, localPathArtifact);
+        location.setInstancesNumber(applicationName, instances, localArtifactPath);
         updateInstancesSensor(location.getInstancesNumber(applicationName));
     }
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryClientRegistry.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryClientRegistry.java
@@ -20,7 +20,7 @@ package org.apache.brooklyn.cloudfoundry.location;
 
 
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.cloudfoundry.client.lib.CloudFoundryOperations;
+import org.cloudfoundry.operations.CloudFoundryOperations;
 
 public interface CloudFoundryClientRegistry {
 

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -40,6 +40,7 @@ import org.cloudfoundry.operations.applications.GetApplicationEnvironmentsReques
 import org.cloudfoundry.operations.applications.GetApplicationRequest;
 import org.cloudfoundry.operations.applications.PushApplicationRequest;
 import org.cloudfoundry.operations.applications.RestartApplicationRequest;
+import org.cloudfoundry.operations.applications.ScaleApplicationRequest;
 import org.cloudfoundry.operations.applications.SetEnvironmentVariableApplicationRequest;
 import org.cloudfoundry.operations.applications.StartApplicationRequest;
 import org.cloudfoundry.operations.applications.StopApplicationRequest;
@@ -308,13 +309,12 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         return result;
     }
 
-    public void setMemory(String applicationName, int memory, String artifact) {
+    public void setMemory(String applicationName, int memory) {
         try {
             getClient().applications()
-                    .push(PushApplicationRequest.builder()
+                    .scale(ScaleApplicationRequest.builder()
                             .name(applicationName)
-                            .memory(memory)
-                            .application(Paths.get(artifact))
+                            .memoryLimit(memory)
                             .build())
                     .toFuture()
                     .get();
@@ -323,13 +323,12 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         }
     }
 
-    public void setDiskQuota(String applicationName, int diskQuota, String artifact) {
+    public void setDiskQuota(String applicationName, int diskQuota) {
         try {
             getClient().applications()
-                    .push(PushApplicationRequest.builder()
+                    .scale(ScaleApplicationRequest.builder()
                             .name(applicationName)
-                            .diskQuota(diskQuota)
-                            .application(Paths.get(artifact))
+                            .diskLimit(diskQuota)
                             .build())
                     .toFuture()
                     .get();
@@ -338,13 +337,12 @@ public class CloudFoundryPaasLocation extends AbstractLocation
         }
     }
 
-    public void setInstancesNumber(String applicationName, int instances, String artifact) {
+    public void setInstancesNumber(String applicationName, int instances) {
         try {
             getClient().applications()
-                    .push(PushApplicationRequest.builder()
+                    .scale(ScaleApplicationRequest.builder()
                             .name(applicationName)
                             .instances(instances)
-                            .application(Paths.get(artifact))
                             .build())
                     .toFuture()
                     .get();

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocation.java
@@ -83,7 +83,8 @@ public class CloudFoundryPaasLocation extends AbstractLocation implements PaasLo
     protected CloudFoundryOperations getClient(ConfigBag config) {
         if (client == null) {
             CloudFoundryClientRegistry registry = getConfig(CF_CLIENT_REGISTRY);
-            client = registry.getCloudFoundryClient(ResolvingConfigBag.newInstanceExtending(getManagementContext(), config), true);
+            client = registry.getCloudFoundryClient(
+                    ResolvingConfigBag.newInstanceExtending(getManagementContext(), config), true);
         }
         return client;
     }
@@ -91,7 +92,8 @@ public class CloudFoundryPaasLocation extends AbstractLocation implements PaasLo
     public String deploy(Map<?, ?> params) {
         ConfigBag appSetUp = ConfigBag.newInstance(params);
         String artifactLocalPath = appSetUp.get(VanillaCloudFoundryApplication.ARTIFACT_PATH);
-        String applicationName = appSetUp.get(VanillaCloudFoundryApplication.APPLICATION_NAME);
+        String applicationName = appSetUp
+                .get(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey());
 
         getClient().createApplication(applicationName, getStaging(appSetUp),
                 appSetUp.get(VanillaCloudFoundryApplication.REQUIRED_DISK),
@@ -125,7 +127,7 @@ public class CloudFoundryPaasLocation extends AbstractLocation implements PaasLo
 
         String host = config.get(VanillaCloudFoundryApplication.APPLICATION_HOST);
         if (Strings.isBlank(host)) {
-            host = config.get(VanillaCloudFoundryApplication.APPLICATION_NAME);
+            host = config.get(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey());
         }
 
         return host + "." + domainId;

--- a/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
+++ b/src/main/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationConfig.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
+import java.time.Duration;
+
 import org.apache.brooklyn.cloudfoundry.location.paas.PaasLocationConfig;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -34,4 +36,6 @@ public interface CloudFoundryPaasLocationConfig extends PaasLocationConfig {
             CloudFoundryClientRegistry.class, "cloudFoundryPaasClientRegistry",
             "Registry/Factory for creating cloudfoundry client; default is almost always fine, " +
                     "except where tests want to customize behaviour", CloudFoundryClientRegistryImpl.INSTANCE);
+    ConfigKey<Duration> OPERATIONS_TIMEOUT = ConfigKeys.newConfigKey(Duration.class,
+            "operations.timeout", "Timeout for cloudfoundry operations", Duration.ofMinutes(5));
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/AbstractCloudFoundryLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/AbstractCloudFoundryLiveTest.java
@@ -18,14 +18,19 @@
  */
 package org.apache.brooklyn.cloudfoundry;
 
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Map;
 import java.util.UUID;
 
+import org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication;
 import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.util.text.Strings;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
@@ -36,6 +41,7 @@ public class AbstractCloudFoundryLiveTest extends BrooklynAppLiveTestSupport
     protected static final String DEFAULT_DOMAIN = "cfapps.io";
     protected final String LOCATION_SPEC_NAME = "pivotal-ws";
     protected final String JAVA_BUILDPACK = "https://github.com/cloudfoundry/java-buildpack.git";
+
 
     protected String applicationName;
     protected CloudFoundryPaasLocation cloudFoundryPaasLocation;
@@ -63,6 +69,23 @@ public class AbstractCloudFoundryLiveTest extends BrooklynAppLiveTestSupport
 
     protected LocalManagementContext newLocalManagementContext() {
         return new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+    }
+
+    public static String inferApplicationUrl(Map<String, Object> params) {
+        String host = (String) params
+                .get(VanillaCloudFoundryApplication.APPLICATION_HOST.getName());
+        if (Strings.isBlank(host)) {
+            host = (String) params
+                    .get(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey().getName());
+        }
+        String domain = (String) params
+                .get(VanillaCloudFoundryApplication.APPLICATION_DOMAIN.getName());
+        if (Strings.isBlank(domain)) {
+            domain = DEFAULT_DOMAIN;
+        }
+        assertNotNull(host);
+        assertNotNull(domain);
+        return "https://" + host + "." + domain;
     }
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/AbstractCloudFoundryUnitTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/AbstractCloudFoundryUnitTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.cloudfoundry;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.Map;
 import java.util.UUID;
@@ -26,9 +27,11 @@ import java.util.UUID;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication;
 import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocationTest;
 import org.apache.brooklyn.cloudfoundry.location.StubbedCloudFoundryPaasClientRegistry;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.text.Strings;
 import org.testng.annotations.BeforeMethod;
 
@@ -37,14 +40,13 @@ public class AbstractCloudFoundryUnitTest extends BrooklynAppUnitTestSupport
 
     protected static final String APPLICATION_NAME = UUID.randomUUID().toString().substring(0, 8);
 
-    protected static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
+    public static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
 
     protected static final String DEFAULT_APPLICATION_BROOKLYN_DOMAIN
             = APPLICATION_NAME + "." + BROOKLYN_DOMAIN;
     protected static final String DEFAULT_APPLICATION_ADDRESS
             = "https://" + DEFAULT_APPLICATION_BROOKLYN_DOMAIN;
     protected static final String MOCK_BUILDPACK = Strings.makeRandomId(20);
-    protected static final String MOCK_HOST = "mockedhost";
 
     protected CloudFoundryPaasLocation cloudFoundryPaasLocation;
 
@@ -91,6 +93,20 @@ public class AbstractCloudFoundryUnitTest extends BrooklynAppUnitTestSupport
                 entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_DISK));
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES),
                 entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_INSTANCES));
+    }
+
+    public String inferApplicationUrl(ConfigBag params) {
+        String host = params.get(VanillaCloudFoundryApplication.APPLICATION_HOST);
+        if (Strings.isBlank(host)) {
+            host = params.get(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey());
+        }
+        String domain = params.get(VanillaCloudFoundryApplication.APPLICATION_DOMAIN);
+        if (Strings.isBlank(domain)) {
+            domain = CloudFoundryPaasLocationTest.BROOKLYN_DOMAIN;
+        }
+        assertNotNull(host);
+        assertNotNull(domain);
+        return "https://" + host + "." + domain;
     }
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/CloudFoundryTestFixtures.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/CloudFoundryTestFixtures.java
@@ -32,7 +32,9 @@ public interface CloudFoundryTestFixtures {
     public static final int CUSTOM_INSTANCES = INSTANCES * 2;
     public static final String APPLICATION_ARTIFACT =
             "brooklyn-example-hello-world-sql-webapp-in-paas.war";
-    public static final String APPLICATION_ARTIFACT_URL = "classpath://" + APPLICATION_ARTIFACT;
+    public static final String ARTIFACT_URL = "classpath://" + APPLICATION_ARTIFACT;
     public static final Map<String, String> EMPTY_ENV = MutableMap.of();
     public static final Map<String, String> SIMPLE_ENV = MutableMap.of("k1", "v1");
+    public static final String BROOKLYN_HOST = "test-brooklyn-host";
+
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationLiveTest.java
@@ -46,11 +46,10 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
         startAndCheckEntitySensorsAndDefaultProfile(entity, cloudFoundryPaasLocation);
-
         assertTrue(entity.getAttribute(VanillaCloudFoundryApplication.ENV).isEmpty());
     }
 
@@ -59,24 +58,21 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
-
         startAndCheckEntitySensors(entity, cloudFoundryPaasLocation);
     }
 
     @Test(groups = {"Live"})
     public void testDeployApplicationWitEnv() throws IOException {
         Map<String, String> env = MutableMap.copyOf(SIMPLE_ENV);
-
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
                         .configure(VanillaCloudFoundryApplication.ENV, env)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
-
         startAndCheckEntitySensors(entity, cloudFoundryPaasLocation);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ENV), env);
     }
@@ -87,7 +83,7 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
 
@@ -101,23 +97,44 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
     }
 
     @Test(groups = {"Live"})
-    public void testModifyApplicationResources() throws IOException {
+    public void testModifyApplicationMemory() throws IOException {
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
-
         startAndCheckEntitySensorsAndDefaultProfile(entity, cloudFoundryPaasLocation);
 
         entity.setMemory(CUSTOM_MEMORY);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY).intValue(),
                 CUSTOM_MEMORY);
+    }
+
+    @Test(groups = {"Live"})
+    public void testModifyApplicationDiskQuota() throws IOException {
+        final VanillaCloudFoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
+                        .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
+                        .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
+        startAndCheckEntitySensorsAndDefaultProfile(entity, cloudFoundryPaasLocation);
 
         entity.setDiskQuota(CUSTOM_DISK);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK).intValue(),
                 CUSTOM_DISK);
+    }
+
+    @Test(groups = {"Live"})
+    public void testModifyApplicationInstances() throws IOException {
+        final VanillaCloudFoundryApplication entity =
+                app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
+                        .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
+                        .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
+        startAndCheckEntitySensorsAndDefaultProfile(entity, cloudFoundryPaasLocation);
 
         entity.setInstancesNumber(CUSTOM_INSTANCES);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
@@ -129,11 +146,11 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
-
         startAndCheckEntitySensors(entity, cloudFoundryPaasLocation);
+
         entity.stop();
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
@@ -149,10 +166,11 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
         final VanillaCloudFoundryApplication entity =
                 app.createAndManageChild(EntitySpec.create(VanillaCloudFoundryApplication.class)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName)
-                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                        .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                         .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN)
                         .configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK));
         startAndCheckEntitySensorsAndDefaultProfile(entity, cloudFoundryPaasLocation);
+
         entity.restart();
         checkEntityIsRunningAndAvailable(entity);
     }
@@ -173,7 +191,6 @@ public class VanillaCloudFoundryApplicationLiveTest extends AbstractCloudFoundry
         });
         assertFalse(Strings.isBlank(entity.getAttribute(Attributes.MAIN_URI).toString()));
         assertFalse(Strings.isBlank(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL)));
-
     }
 
     private void startAndCheckEntitySensorsAndDefaultProfile(VanillaCloudFoundryApplication entity,

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
@@ -155,8 +155,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
 
         entity.setMemory(CUSTOM_MEMORY);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY).intValue(), CUSTOM_MEMORY);
-        //TODO: verify(location, times(1)).setMemory(APPLICATION_NAME, CUSTOM_MEMORY);
-        //currently not possible because artifact path is required
+        verify(location, times(1)).setMemory(APPLICATION_NAME, CUSTOM_MEMORY);
     }
 
     @Test
@@ -174,8 +173,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
         entity.setDiskQuota(CUSTOM_DISK);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK).intValue(),
                 CUSTOM_DISK);
-        //TODO verify(location, times(1)).setDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
-        //currently not possible because artifact path is required
+        verify(location, times(1)).setDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
     }
 
     @Test
@@ -184,7 +182,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(EMPTY_ENV).when(location).getEnv(anyString());
 
-        doNothing().when(location).setInstancesNumber(anyString(), anyInt(), anyString());
+        doNothing().when(location).setInstancesNumber(anyString(), anyInt());
 
         VanillaCloudFoundryApplication entity = addDefaultVanillaToAppAndMockProfileMethods(location);
         startEntityInLocationAndCheckSensors(entity, location);
@@ -194,8 +192,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
         entity.setInstancesNumber(CUSTOM_INSTANCES);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
                 CUSTOM_INSTANCES);
-        //TODO verify(location, times(1)).setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES);
-        //currently not possible because artifact path is required
+        verify(location, times(1)).setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES);
     }
 
     @Test
@@ -267,9 +264,9 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
     private void mockLocationProfileUsingEntityConfig(CloudFoundryPaasLocation location,
                                                       VanillaCloudFoundryApplication entity) {
         if (new MockUtil().isMock(location)) {
-            doNothing().when(location).setMemory(anyString(), anyInt(), anyString());
-            doNothing().when(location).setDiskQuota(anyString(), anyInt(), anyString());
-            doNothing().when(location).setInstancesNumber(anyString(), anyInt(), anyString());
+            doNothing().when(location).setMemory(anyString(), anyInt());
+            doNothing().when(location).setDiskQuota(anyString(), anyInt());
+            doNothing().when(location).setInstancesNumber(anyString(), anyInt());
 
             doReturn(entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_MEMORY))
                     .when(location).getMemory(anyString());

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryApplicationTest.java
@@ -44,7 +44,6 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
-import org.cloudfoundry.client.lib.StartingInfo;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.MockUtil;
 import org.testng.annotations.AfterMethod;
@@ -59,7 +58,6 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnitTest {
-
     private static final String MOCKED_APP_PATH = "vanilla-cf-app-test";
 
     private MockWebServer mockWebServer;
@@ -87,8 +85,9 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
 
     @Test
     public void testDeployApplication() throws IOException {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
+
         doReturn(EMPTY_ENV).when(location).getEnv(anyString());
         doNothing().when(location).setEnv(anyString(), anyMapOf(String.class, String.class));
 
@@ -102,7 +101,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
 
     @Test
     public void testDeployApplicationWithEnv() throws IOException {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(SIMPLE_ENV).when(location).getEnv(anyString());
         doNothing().when(location).setEnv(anyString(), anyMapOf(String.class, String.class));
@@ -126,7 +125,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
     public void testSetEnvEffector() throws IOException {
         Map<String, String> env = MutableMap.copyOf(EMPTY_ENV);
         CloudFoundryPaasLocation location = spy(cloudFoundryPaasLocation);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(env).when(location).getEnv(anyString());
         doNothing().when(location).setEnv(anyString(), anyMapOf(String.class, String.class));
@@ -144,7 +143,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
 
     @Test
     public void testSetMemory() {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(EMPTY_ENV).when(location).getEnv(anyString());
 
@@ -156,12 +155,13 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
 
         entity.setMemory(CUSTOM_MEMORY);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY).intValue(), CUSTOM_MEMORY);
-        verify(location, times(1)).setMemory(APPLICATION_NAME, CUSTOM_MEMORY);
+        //TODO: verify(location, times(1)).setMemory(APPLICATION_NAME, CUSTOM_MEMORY);
+        //currently not possible because artifact path is required
     }
 
     @Test
     public void testSetDisk() {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(EMPTY_ENV).when(location).getEnv(anyString());
 
@@ -174,16 +174,17 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
         entity.setDiskQuota(CUSTOM_DISK);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK).intValue(),
                 CUSTOM_DISK);
-        verify(location, times(1)).setDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
+        //TODO verify(location, times(1)).setDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
+        //currently not possible because artifact path is required
     }
 
     @Test
     public void testSetInstances() {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(EMPTY_ENV).when(location).getEnv(anyString());
 
-        doNothing().when(location).setInstancesNumber(anyString(), anyInt());
+        doNothing().when(location).setInstancesNumber(anyString(), anyInt(), anyString());
 
         VanillaCloudFoundryApplication entity = addDefaultVanillaToAppAndMockProfileMethods(location);
         startEntityInLocationAndCheckSensors(entity, location);
@@ -193,12 +194,13 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
         entity.setInstancesNumber(CUSTOM_INSTANCES);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
                 CUSTOM_INSTANCES);
-        verify(location, times(1)).setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES);
+        //TODO verify(location, times(1)).setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES);
+        //currently not possible because artifact path is required
     }
 
     @Test
     public void testStopApplication() {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doNothing().when(location).stopApplication(anyString());
         doNothing().when(location).deleteApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
@@ -220,7 +222,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
 
     @Test
     public void testRestartApplication() {
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doNothing().when(location).restartApplication(anyString());
         doReturn(serverAddress).when(location).deploy(anyMap());
         doReturn(EMPTY_ENV).when(location).getEnv(anyString());
@@ -253,7 +255,7 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
         EntitySpec<VanillaCloudFoundryApplication> vanilla = EntitySpec
                 .create(VanillaCloudFoundryApplication.class)
                 .configure(VanillaCloudFoundryApplication.APPLICATION_NAME, APPLICATION_NAME)
-                .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_ARTIFACT_URL)
+                .configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL)
                 .configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, BROOKLYN_DOMAIN)
                 .configure(VanillaCloudFoundryApplication.BUILDPACK, MOCK_BUILDPACK);
         if (env != null) {
@@ -265,9 +267,9 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
     private void mockLocationProfileUsingEntityConfig(CloudFoundryPaasLocation location,
                                                       VanillaCloudFoundryApplication entity) {
         if (new MockUtil().isMock(location)) {
-            doNothing().when(location).setMemory(anyString(), anyInt());
-            doNothing().when(location).setDiskQuota(anyString(), anyInt());
-            doNothing().when(location).setInstancesNumber(anyString(), anyInt());
+            doNothing().when(location).setMemory(anyString(), anyInt(), anyString());
+            doNothing().when(location).setDiskQuota(anyString(), anyInt(), anyString());
+            doNothing().when(location).setInstancesNumber(anyString(), anyInt(), anyString());
 
             doReturn(entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_MEMORY))
                     .when(location).getMemory(anyString());
@@ -302,5 +304,4 @@ public class VanillaCloudFoundryApplicationTest extends AbstractCloudFoundryUnit
             }
         };
     }
-
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryYamlLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryYamlLiveTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.cloudfoundry.entity;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -32,56 +33,102 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.launcher.camp.SimpleYamlLauncher;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.text.Strings;
 import org.testng.annotations.Test;
 
 public class VanillaCloudFoundryYamlLiveTest {
 
+    private static final String DEFAULT_ID = "vanilla-app";
+    private static final String DEFAULT_DOMAIN = "cfapps.io";
+
     @Test(groups = {"Live"})
-    public void deployWebappFromYaml() {
+    public void deploySimpleWebapp() {
         SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
-        Application app = launcher.launchAppYaml("vanilla-cf-stadalone.yml").getApplication();
+        Application app = launcher.launchAppYaml("vanilla-cf-standalone.yml").getApplication();
 
-        final VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
-                findChildEntitySpecByPlanId(app, "vanilla-app");
+        VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
+                findChildEntitySpecByPlanId(app, DEFAULT_ID);
+        testEntitySensors(entity);
+    }
 
-        Asserts.succeedsEventually(new Runnable() {
-            public void run() {
-                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
-                assertTrue(entity.getAttribute(VanillaCloudFoundryApplication
-                        .SERVICE_PROCESS_IS_RUNNING));
+    @Test(groups = {"Live"})
+    public void deployWebappWithName() {
+        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
+        launcher.setShutdownAppsOnExit(true);
+        Application app = launcher.launchAppYaml("vanilla-cf-app-name.yml").getApplication();
 
-                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
-                assertNotNull(entity.getAttribute(Attributes.MAIN_URI).toString());
-                assertNotNull(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL));
-            }
-        });
+        VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
+                findChildEntitySpecByPlanId(app, DEFAULT_ID);
+        testEntitySensors(entity);
+        String name = entity.getAttribute(VanillaCloudFoundryApplication.APPLICATION_NAME);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL),
+                createApplicationUrl(name));
+    }
+
+    @Test(groups = {"Live"})
+    public void deployWebappWitDomain() {
+        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
+        launcher.setShutdownAppsOnExit(true);
+        Application app = launcher.launchAppYaml("vanilla-cf-domain.yml").getApplication();
+
+        VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
+                findChildEntitySpecByPlanId(app, DEFAULT_ID);
+        testEntitySensors(entity);
+
+        String domain = entity.getConfig(VanillaCloudFoundryApplication.APPLICATION_DOMAIN);
+        assertFalse(Strings.isBlank(domain));
+        String name = entity.getAttribute(VanillaCloudFoundryApplication.APPLICATION_NAME);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL),
+                createApplicationUrl(name, domain));
+    }
+
+    @Test(groups = {"Live"})
+    public void deployWebappWitHostAndDomain() {
+        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
+        launcher.setShutdownAppsOnExit(true);
+        Application app = launcher.launchAppYaml("vanilla-cf-host-and-domain.yml").getApplication();
+
+        VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
+                findChildEntitySpecByPlanId(app, DEFAULT_ID);
+        testEntitySensors(entity);
+
+        String domain = entity.getConfig(VanillaCloudFoundryApplication.APPLICATION_DOMAIN);
+        String host = entity.getConfig(VanillaCloudFoundryApplication.APPLICATION_HOST);
+        assertFalse(Strings.isBlank(domain));
+        assertFalse(Strings.isBlank(host));
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL),
+                createApplicationUrl(host, domain));
     }
 
     @Test(groups = {"Live"})
     @SuppressWarnings("unchecked")
-    public void deployWebappWithEnvFromYaml() {
+    public void deployWebappWithEnv() {
         SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-env.yml").getApplication();
 
-        final VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
-                findChildEntitySpecByPlanId(app, "vanilla-app");
-
-        Asserts.succeedsEventually(new Runnable() {
-            public void run() {
-                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
-                assertTrue(entity.getAttribute(VanillaCloudFoundryApplication
-                        .SERVICE_PROCESS_IS_RUNNING));
-
-                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
-                assertNotNull(entity.getAttribute(Attributes.MAIN_URI).toString());
-                assertNotNull(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL));
-            }
-        });
+        VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
+                findChildEntitySpecByPlanId(app, DEFAULT_ID);
+        testEntitySensors(entity);
         Map<String, String> env = (Map<String, String>)
                 entity.getAttribute(VanillaCloudFoundryApplication.ENV);
         assertEquals(env, MutableMap.of("env1", "value1", "env2", "2", "env3", "value3"));
+    }
+
+    @Test(groups = {"Live"})
+    public void deployWebappResourceProfile() {
+        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
+        launcher.setShutdownAppsOnExit(true);
+        Application app = launcher.launchAppYaml("vanilla-cf-resources-profile.yml").getApplication();
+
+        VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
+                findChildEntitySpecByPlanId(app, DEFAULT_ID);
+        testEntitySensors(entity);
+
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY).intValue(), 1024);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(), 1);
+        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK).intValue(), 2048);
     }
 
     private Entity findChildEntitySpecByPlanId(Application app, String planId) {
@@ -92,6 +139,27 @@ public class VanillaCloudFoundryYamlLiveTest {
             }
         }
         return null;
+    }
+
+    private void testEntitySensors(final VanillaCloudFoundryApplication entity) {
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                assertTrue(entity.getAttribute(VanillaCloudFoundryApplication
+                        .SERVICE_PROCESS_IS_RUNNING));
+                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                assertNotNull(entity.getAttribute(Attributes.MAIN_URI).toString());
+                assertNotNull(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL));
+            }
+        });
+    }
+
+    private String createApplicationUrl(String host) {
+        return createApplicationUrl(host, DEFAULT_DOMAIN);
+    }
+
+    private String createApplicationUrl(String host, String domain) {
+        return "https://" + host + "." + domain;
     }
 
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryYamlLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaCloudFoundryYamlLiveTest.java
@@ -30,10 +30,13 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.launcher.SimpleYamlLauncherForTests;
 import org.apache.brooklyn.launcher.camp.SimpleYamlLauncher;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class VanillaCloudFoundryYamlLiveTest {
@@ -41,9 +44,21 @@ public class VanillaCloudFoundryYamlLiveTest {
     private static final String DEFAULT_ID = "vanilla-app";
     private static final String DEFAULT_DOMAIN = "cfapps.io";
 
+    private SimpleYamlLauncher launcher;
+
+    @BeforeMethod
+    public void setUp() {
+        launcher = new SimpleYamlLauncherForTests();
+        launcher.setShutdownAppsOnExit(true);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        launcher.destroyAll();
+    }
+
     @Test(groups = {"Live"})
     public void deploySimpleWebapp() {
-        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-standalone.yml").getApplication();
 
@@ -54,7 +69,6 @@ public class VanillaCloudFoundryYamlLiveTest {
 
     @Test(groups = {"Live"})
     public void deployWebappWithName() {
-        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-app-name.yml").getApplication();
 
@@ -68,7 +82,6 @@ public class VanillaCloudFoundryYamlLiveTest {
 
     @Test(groups = {"Live"})
     public void deployWebappWitDomain() {
-        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-domain.yml").getApplication();
 
@@ -85,7 +98,6 @@ public class VanillaCloudFoundryYamlLiveTest {
 
     @Test(groups = {"Live"})
     public void deployWebappWitHostAndDomain() {
-        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-host-and-domain.yml").getApplication();
 
@@ -104,21 +116,18 @@ public class VanillaCloudFoundryYamlLiveTest {
     @Test(groups = {"Live"})
     @SuppressWarnings("unchecked")
     public void deployWebappWithEnv() {
-        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-env.yml").getApplication();
 
         VanillaCloudFoundryApplication entity = (VanillaCloudFoundryApplication)
                 findChildEntitySpecByPlanId(app, DEFAULT_ID);
         testEntitySensors(entity);
-        Map<String, String> env = (Map<String, String>)
-                entity.getAttribute(VanillaCloudFoundryApplication.ENV);
+        Map<String, String> env = entity.getAttribute(VanillaCloudFoundryApplication.ENV);
         assertEquals(env, MutableMap.of("env1", "value1", "env2", "2", "env3", "value3"));
     }
 
     @Test(groups = {"Live"})
     public void deployWebappResourceProfile() {
-        SimpleYamlLauncher launcher = new SimpleYamlLauncher();
         launcher.setShutdownAppsOnExit(true);
         Application app = launcher.launchAppYaml("vanilla-cf-resources-profile.yml").getApplication();
 
@@ -142,16 +151,17 @@ public class VanillaCloudFoundryYamlLiveTest {
     }
 
     private void testEntitySensors(final VanillaCloudFoundryApplication entity) {
-        Asserts.succeedsEventually(new Runnable() {
-            public void run() {
-                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
-                assertTrue(entity.getAttribute(VanillaCloudFoundryApplication
-                        .SERVICE_PROCESS_IS_RUNNING));
-                assertTrue(entity.getAttribute(Startable.SERVICE_UP));
-                assertNotNull(entity.getAttribute(Attributes.MAIN_URI).toString());
-                assertNotNull(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL));
-            }
-        });
+        Asserts.succeedsEventually(
+                new Runnable() {
+                    public void run() {
+                        assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                        assertTrue(entity.getAttribute(VanillaCloudFoundryApplication
+                                .SERVICE_PROCESS_IS_RUNNING));
+                        assertTrue(entity.getAttribute(Startable.SERVICE_UP));
+                        assertNotNull(entity.getAttribute(Attributes.MAIN_URI).toString());
+                        assertNotNull(entity.getAttribute(VanillaCloudFoundryApplication.ROOT_URL));
+                    }
+                });
     }
 
     private String createApplicationUrl(String host) {

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
@@ -215,7 +215,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
                 entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY);
         assertEquals(memory, CUSTOM_MEMORY);
         verify(location, times(1))
-                .setMemory(entity.getApplicationName(), CUSTOM_MEMORY, driver.localPathArtifact);
+                .setMemory(entity.getApplicationName(), CUSTOM_MEMORY, driver.localArtifactPath);
     }
 
     @Test
@@ -241,7 +241,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
         int disk = entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK);
         assertEquals(disk, CUSTOM_DISK);
         verify(location, times(1))
-                .setDiskQuota(entity.getApplicationName(), CUSTOM_DISK, driver.localPathArtifact);
+                .setDiskQuota(entity.getApplicationName(), CUSTOM_DISK, driver.localArtifactPath);
     }
 
     @Test
@@ -268,7 +268,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
         driver.setInstancesNumber(CUSTOM_INSTANCES);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
                 CUSTOM_INSTANCES);
-        verify(location, times(1)).setInstancesNumber(entity.getApplicationName(), CUSTOM_INSTANCES, driver.localPathArtifact);
+        verify(location, times(1)).setInstancesNumber(entity.getApplicationName(), CUSTOM_INSTANCES, driver.localArtifactPath);
     }
 
     @Test

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
@@ -215,7 +215,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
                 entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY);
         assertEquals(memory, CUSTOM_MEMORY);
         verify(location, times(1))
-                .setMemory(entity.getApplicationName(), CUSTOM_MEMORY, driver.localArtifactPath);
+                .setMemory(entity.getApplicationName(), CUSTOM_MEMORY);
     }
 
     @Test
@@ -241,7 +241,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
         int disk = entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK);
         assertEquals(disk, CUSTOM_DISK);
         verify(location, times(1))
-                .setDiskQuota(entity.getApplicationName(), CUSTOM_DISK, driver.localArtifactPath);
+                .setDiskQuota(entity.getApplicationName(), CUSTOM_DISK);
     }
 
     @Test
@@ -268,7 +268,7 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
         driver.setInstancesNumber(CUSTOM_INSTANCES);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
                 CUSTOM_INSTANCES);
-        verify(location, times(1)).setInstancesNumber(entity.getApplicationName(), CUSTOM_INSTANCES, driver.localArtifactPath);
+        verify(location, times(1)).setInstancesNumber(entity.getApplicationName(), CUSTOM_INSTANCES);
     }
 
     @Test
@@ -325,9 +325,9 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     private void mockLocationProfileUsingEntityConfig(CloudFoundryPaasLocation location,
                                                       VanillaCloudFoundryApplication entity) {
         if (new MockUtil().isMock(location)) {
-            doNothing().when(location).setMemory(anyString(), anyInt(), anyString());
-            doNothing().when(location).setDiskQuota(anyString(), anyInt(), anyString());
-            doNothing().when(location).setInstancesNumber(anyString(), anyInt(), anyString());
+            doNothing().when(location).setMemory(anyString(), anyInt());
+            doNothing().when(location).setDiskQuota(anyString(), anyInt());
+            doNothing().when(location).setInstancesNumber(anyString(), anyInt());
 
             when(location.getMemory(anyString()))
                     .thenReturn(entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_MEMORY));

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/entity/VanillaPaasApplicationCloudFoundryDriverTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -34,14 +33,12 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.Map;
 
 import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
 import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.cloudfoundry.client.lib.StartingInfo;
 import org.mockito.MockitoAnnotations;
 import org.mockito.internal.util.MockUtil;
 import org.testng.annotations.BeforeMethod;
@@ -54,6 +51,7 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudFoundryUnitTest {
+
     CloudFoundryPaasLocation location;
 
     private MockWebServer mockWebServer;
@@ -72,13 +70,14 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     }
 
     @Test
-    public void testStartApplication() throws MalformedURLException {
+    public void testStartApplication() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(EMPTY_ENV);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
         entity.setManagementContext(mgmt);
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         mockLocationProfileUsingEntityConfig(location, entity);
 
         assertNull(entity.getAttribute(Attributes.MAIN_URI));
@@ -96,10 +95,11 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     @Test
     public void testStartApplicationWithEnv() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(SIMPLE_ENV);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ENV, SIMPLE_ENV);
         entity.setManagementContext(mgmt);
 
@@ -119,10 +119,11 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     @Test
     public void testStartApplicationWithoutEnv() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(EMPTY_ENV);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setManagementContext(mgmt);
 
         assertNull(entity.getAttribute(Attributes.MAIN_URI));
@@ -143,10 +144,11 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     public void testSetEnvToApplication() {
         Map<String, String> env = SIMPLE_ENV;
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(env);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ENV, env);
         entity.setManagementContext(mgmt);
 
@@ -170,10 +172,11 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     public void testSetNullEnvToApplication() {
         Map<String, String> newEnv = null;
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(SIMPLE_ENV);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ENV, SIMPLE_ENV);
         entity.setManagementContext(mgmt);
 
@@ -190,69 +193,73 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     @Test
     public void testSetMemory() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(EMPTY_ENV);
         when(location.getMemory(anyString())).thenReturn(CUSTOM_MEMORY);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setManagementContext(mgmt);
         mockLocationProfileUsingEntityConfig(location, entity);
         when(location.getMemory(anyString())).thenReturn(
-                entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_MEMORY),
-                CUSTOM_MEMORY);
+                entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_MEMORY), CUSTOM_MEMORY);
 
-        VanillaPaasApplicationDriver driver =
+        VanillaPaasApplicationCloudFoundryDriver driver =
                 new VanillaPaasApplicationCloudFoundryDriver(entity, location);
         driver.start();
         assertTrue(driver.isRunning());
         checkDefaultResourceProfile(entity);
 
         driver.setMemory(CUSTOM_MEMORY);
-        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY).intValue(),
-                CUSTOM_MEMORY);
-        verify(location, times(1)).setMemory(entity.getApplicationName(), CUSTOM_MEMORY);
+        int memory =
+                entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_MEMORY);
+        assertEquals(memory, CUSTOM_MEMORY);
+        verify(location, times(1))
+                .setMemory(entity.getApplicationName(), CUSTOM_MEMORY, driver.localPathArtifact);
     }
 
     @Test
     public void testSetDisk() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(EMPTY_ENV);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setManagementContext(mgmt);
         mockLocationProfileUsingEntityConfig(location, entity);
         when(location.getDiskQuota(anyString())).thenReturn(
-                entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_DISK),
-                CUSTOM_DISK);
+                entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_DISK), CUSTOM_DISK);
 
-        VanillaPaasApplicationDriver driver =
+        VanillaPaasApplicationCloudFoundryDriver driver =
                 new VanillaPaasApplicationCloudFoundryDriver(entity, location);
         driver.start();
         assertTrue(driver.isRunning());
         checkDefaultResourceProfile(entity);
 
         driver.setDiskQuota(CUSTOM_DISK);
-        assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK).intValue(),
-                CUSTOM_DISK);
-        verify(location, times(1)).setDiskQuota(entity.getApplicationName(), CUSTOM_DISK);
+        int disk = entity.getAttribute(VanillaCloudFoundryApplication.ALLOCATED_DISK);
+        assertEquals(disk, CUSTOM_DISK);
+        verify(location, times(1))
+                .setDiskQuota(entity.getApplicationName(), CUSTOM_DISK, driver.localPathArtifact);
     }
 
     @Test
     public void testSetInstances() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         when(location.getEnv(anyString())).thenReturn(EMPTY_ENV);
         when(location.getInstancesNumber(anyString())).thenReturn(CUSTOM_INSTANCES);
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setManagementContext(mgmt);
         mockLocationProfileUsingEntityConfig(location, entity);
-        when(location.getInstancesNumber(anyString())).thenReturn(
-                entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_INSTANCES),
-                CUSTOM_INSTANCES);
+        when(location.getInstancesNumber(anyString()))
+                .thenReturn(entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_INSTANCES),
+                        CUSTOM_INSTANCES);
 
-        VanillaPaasApplicationDriver driver =
+        VanillaPaasApplicationCloudFoundryDriver driver =
                 new VanillaPaasApplicationCloudFoundryDriver(entity, location);
         driver.start();
         assertTrue(driver.isRunning());
@@ -261,16 +268,17 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
         driver.setInstancesNumber(CUSTOM_INSTANCES);
         assertEquals(entity.getAttribute(VanillaCloudFoundryApplication.INSTANCES).intValue(),
                 CUSTOM_INSTANCES);
-        verify(location, times(1)).setInstancesNumber(entity.getApplicationName(), CUSTOM_INSTANCES);
+        verify(location, times(1)).setInstancesNumber(entity.getApplicationName(), CUSTOM_INSTANCES, driver.localPathArtifact);
     }
 
     @Test
     public void testStopApplication() throws IOException {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doNothing().when(location).stopApplication(anyString());
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setManagementContext(mgmt);
 
         VanillaPaasApplicationDriver driver =
@@ -287,10 +295,11 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     @Test
     public void testRestartApplication() {
         when(location.deploy(anyMap())).thenReturn(applicationUrl);
-        doReturn(new StartingInfo(null)).when(location).startApplication(anyString());
+        doNothing().when(location).startApplication(anyString());
         doNothing().when(location).restartApplication(anyString());
 
         VanillaCloudFoundryApplicationImpl entity = new VanillaCloudFoundryApplicationImpl();
+        entity.setConfigEvenIfOwned(VanillaCloudFoundryApplication.ARTIFACT_PATH, ARTIFACT_URL);
         entity.setManagementContext(mgmt);
 
         VanillaPaasApplicationDriver driver =
@@ -316,9 +325,9 @@ public class VanillaPaasApplicationCloudFoundryDriverTest extends AbstractCloudF
     private void mockLocationProfileUsingEntityConfig(CloudFoundryPaasLocation location,
                                                       VanillaCloudFoundryApplication entity) {
         if (new MockUtil().isMock(location)) {
-            doNothing().when(location).setMemory(anyString(), anyInt());
-            doNothing().when(location).setDiskQuota(anyString(), anyInt());
-            doNothing().when(location).setInstancesNumber(anyString(), anyInt());
+            doNothing().when(location).setMemory(anyString(), anyInt(), anyString());
+            doNothing().when(location).setDiskQuota(anyString(), anyInt(), anyString());
+            doNothing().when(location).setInstancesNumber(anyString(), anyInt(), anyString());
 
             when(location.getMemory(anyString()))
                     .thenReturn(entity.getConfig(VanillaCloudFoundryApplication.REQUIRED_MEMORY));

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryLocationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryLocationLiveTest.java
@@ -159,14 +159,29 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
         assertEquals(cloudFoundryPaasLocation.getDiskQuota(applicationName), DISK);
         assertEquals(cloudFoundryPaasLocation.getInstancesNumber(applicationName), INSTANCES);
 
-        cloudFoundryPaasLocation.setMemory(applicationName, CUSTOM_MEMORY, artifactLocalPath);
-        cloudFoundryPaasLocation.setDiskQuota(applicationName, CUSTOM_DISK, artifactLocalPath);
-        cloudFoundryPaasLocation.setInstancesNumber(applicationName, CUSTOM_INSTANCES, artifactLocalPath);
+        cloudFoundryPaasLocation.setMemory(applicationName, CUSTOM_MEMORY);
+        cloudFoundryPaasLocation.setDiskQuota(applicationName, CUSTOM_DISK);
+        cloudFoundryPaasLocation.setInstancesNumber(applicationName, CUSTOM_INSTANCES);
 
         assertEquals(cloudFoundryPaasLocation.getMemory(applicationName), CUSTOM_MEMORY);
         assertEquals(cloudFoundryPaasLocation.getDiskQuota(applicationName), CUSTOM_DISK);
         assertEquals(cloudFoundryPaasLocation.getInstancesNumber(applicationName), CUSTOM_INSTANCES);
         destroyApplication(applicationName, applicationUrl);
+    }
+
+    @Test(groups = {"Live"}, expectedExceptions = PropagatedRuntimeException.class)
+    public void testSetMemoryNonExistentApplication() {
+        cloudFoundryPaasLocation.setMemory(applicationName, MEMORY);
+    }
+
+    @Test(groups = {"Live"}, expectedExceptions = PropagatedRuntimeException.class)
+    public void testSetDiskQuotaNonExistentApplication() {
+        cloudFoundryPaasLocation.setDiskQuota(applicationName, DISK);
+    }
+
+    @Test(groups = {"Live"}, expectedExceptions = PropagatedRuntimeException.class)
+    public void testSetInstancesNonExistentApplication() {
+        cloudFoundryPaasLocation.setInstancesNumber(applicationName, INSTANCES);
     }
 
     @Test(groups = {"Live"})

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryLocationLiveTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryLocationLiveTest.java
@@ -58,7 +58,7 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
     @Test(groups = {"Live"})
     public void testWebApplicationManagement() throws Exception {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), applicationName);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, artifactLocalPath);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK);
 
@@ -68,7 +68,7 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
     @Test(groups = {"Live"})
     public void testWebApplicationManagementWithDomain() throws Exception {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), applicationName);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, artifactLocalPath);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK);
         params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN);
@@ -79,7 +79,7 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
     @Test(groups = {"Live"})
     public void testAddEnvToApplication() throws Exception {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), applicationName);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, artifactLocalPath);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK);
 
@@ -98,7 +98,7 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
     @Test(groups = {"Live"})
     public void testAddNullEnvToApplication() throws Exception {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), applicationName);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, artifactLocalPath);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK);
 
@@ -117,7 +117,7 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
     @Test(groups = {"Live"})
     public void testModifyResourcesForApplication() {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), applicationName);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, artifactLocalPath);
         params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, DEFAULT_DOMAIN);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK);
@@ -143,7 +143,7 @@ public class CloudFoundryLocationLiveTest extends AbstractCloudFoundryLiveTest {
     @Test(groups = {"Live"})
     public void testRestartApplication() {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, applicationName);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), applicationName);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, artifactLocalPath);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, JAVA_BUILDPACK);
 

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -138,7 +138,7 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
     @Test
     public void testInferApplicationRouteUriNoDomain() {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, APPLICATION_NAME);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), APPLICATION_NAME);
 
         assertEquals(cloudFoundryPaasLocation.inferApplicationRouteUri(params),
                 APPLICATION_NAME + "." + BROOKLYN_DOMAIN);
@@ -271,7 +271,7 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
 
     private ConfigBag getDefaultApplicationConfiguration() {
         ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME, APPLICATION_NAME);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), APPLICATION_NAME);
         params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_LOCAL_PATH);
         params.configure(VanillaCloudFoundryApplication.BUILDPACK, MOCK_BUILDPACK);
         return params;
@@ -287,7 +287,7 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
 
     private void testDeployApplication(ConfigBag params) throws IOException {
         String applicationDomain = deployApplication(params);
-        String applicationName = params.get(VanillaCloudFoundryApplication.APPLICATION_NAME);
+        String applicationName = params.get(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey());
         assertEquals(applicationDomain, DEFAULT_APPLICATION_ADDRESS);
         assertEquals(cloudFoundryPaasLocation.getApplicationStatus(applicationName), AppState.STOPPED);
     }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -217,8 +217,19 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getMemory(APPLICATION_NAME), MEMORY);
 
-        cloudFoundryPaasLocation.setMemory(APPLICATION_NAME, CUSTOM_MEMORY, APPLICATION_LOCAL_PATH);
+        cloudFoundryPaasLocation.setMemory(APPLICATION_NAME, CUSTOM_MEMORY);
         assertEquals(cloudFoundryPaasLocation.getMemory(APPLICATION_NAME), CUSTOM_MEMORY);
+    }
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testSetMemoryNonExistentApplication() {
+        cloudFoundryPaasLocation.setMemory(APPLICATION_NAME, MEMORY);
+    }
+
+    @Test
+    public void testGetDiskQuota() {
+        deployApplication(getDefaultApplicationConfiguration());
+        assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), DISK);
     }
 
     @Test
@@ -226,14 +237,13 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), DISK);
 
-        cloudFoundryPaasLocation.setDiskQuota(APPLICATION_NAME, CUSTOM_DISK, APPLICATION_LOCAL_PATH);
+        cloudFoundryPaasLocation.setDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
         assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), CUSTOM_DISK);
     }
 
-    @Test
-    public void testGetDiskQuota() {
-        deployApplication(getDefaultApplicationConfiguration());
-        assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), DISK);
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testSetDiskQuotaNonExistentApplication() {
+        cloudFoundryPaasLocation.setDiskQuota(APPLICATION_NAME, DISK);
     }
 
     @Test
@@ -247,8 +257,13 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getInstancesNumber(APPLICATION_NAME), INSTANCES);
 
-        cloudFoundryPaasLocation.setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES, APPLICATION_LOCAL_PATH);
+        cloudFoundryPaasLocation.setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES);
         assertEquals(cloudFoundryPaasLocation.getInstancesNumber(APPLICATION_NAME), CUSTOM_INSTANCES);
+    }
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testSetInstancesNonExistentApplication() {
+        cloudFoundryPaasLocation.setInstancesNumber(APPLICATION_NAME, INSTANCES);
     }
 
     private ConfigBag getDefaultApplicationConfiguration() {

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.FileSystemNotFoundException;
 import java.util.Map;
 
 import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
@@ -96,7 +95,7 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
         cloudFoundryPaasLocation.deploy(params.getAllConfig());
     }
 
-    @Test(expectedExceptions = FileSystemNotFoundException.class)
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
     public void testUpdateAnNotExistentArtifact() {
         String nonExistentArtifact = Strings.makeRandomId(10);
         cloudFoundryPaasLocation.pushArtifact(APPLICATION_NAME, nonExistentArtifact);
@@ -111,7 +110,7 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
                 AppState.STARTED);
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
     public void testStartNonExistentApplication() {
         cloudFoundryPaasLocation.startApplication(APPLICATION_NAME);
     }
@@ -124,7 +123,7 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
                 AppState.STOPPED);
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
     public void testGetStateNonExistentApplication() {
         cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME);
     }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/CloudFoundryPaasLocationTest.java
@@ -18,33 +18,25 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.FileSystemNotFoundException;
 import java.util.Map;
 
 import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
 import org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication;
+import org.apache.brooklyn.cloudfoundry.location.CloudFoundryPaasLocation.AppState;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
 import org.apache.brooklyn.util.text.Strings;
-import org.cloudfoundry.client.lib.CloudFoundryException;
-import org.cloudfoundry.client.lib.CloudFoundryOperations;
-import org.cloudfoundry.client.lib.StartingInfo;
-import org.cloudfoundry.client.lib.domain.CloudApplication.AppState;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
-
-    private CloudFoundryOperations client;
 
     @SuppressWarnings("all")
     public final String APPLICATION_LOCAL_PATH = getClass()
@@ -53,159 +45,152 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
     @BeforeMethod
     public void setUp() throws Exception {
         super.setUp();
-        client = cloudFoundryPaasLocation.getClient();
     }
 
     @Test
-    public void testDeployApplicationDomain() throws IOException {
-        testDeployApplication(getDefaultApplicationConfiguration());
-        verify(client, times(1)).getDefaultDomain();
+    public void testDeployApplication() {
+        deployApplicationandCheck(getDefaultApplicationConfiguration());
     }
 
     @Test
-    public void testDeployApplicationWithDomain() throws IOException {
+    public void testDeployApplicationWithHost() {
         ConfigBag params = getDefaultApplicationConfiguration();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, BROOKLYN_DOMAIN);
-        testDeployApplication(params);
-        verify(client, never()).getDefaultDomain();
-    }
-
-    @Test(expectedExceptions = RuntimeException.class)
-    public void testDeployApplicationWithNonExistentDomain() throws IOException {
-        ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, Strings.makeRandomId(8));
-        testDeployApplication(params);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_HOST, BROOKLYN_HOST);
+        deployApplicationandCheck(params);
     }
 
     @Test(expectedExceptions = PropagatedRuntimeException.class)
-    public void testDeployNonExistentArtifact() throws IOException {
+    public void testDeployApplicationNoNameNoHost() {
+        ConfigBag params = getDefaultResourcesProfile();
+        params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, APPLICATION_LOCAL_PATH);
+        deployApplicationandCheck(params);
+    }
+
+    @Test
+    public void testDeployApplicationWithDomain() {
         ConfigBag params = getDefaultApplicationConfiguration();
-        params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, Strings.makeRandomId(10));
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, BROOKLYN_DOMAIN);
+        deployApplicationandCheck(params);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testDeployApplicationWithNonExistentDomain() {
+        ConfigBag params = getDefaultResourcesProfile();
+        String nonExistentDomain = Strings.makeRandomId(8);
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, nonExistentDomain);
+        deployApplicationandCheck(params);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testDeployWithoutArtifact() {
+        ConfigBag params = getDefaultResourcesProfile();
+        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), APPLICATION_NAME);
         cloudFoundryPaasLocation.deploy(params.getAllConfig());
     }
 
     @Test(expectedExceptions = PropagatedRuntimeException.class)
-    public void testUpdateAnNotExistentArtifact() throws IOException {
-        cloudFoundryPaasLocation.pushArtifact(APPLICATION_NAME, Strings.makeRandomId(10));
+    public void testDeployNonExistentArtifact() {
+        ConfigBag params = getDefaultApplicationConfiguration();
+        String nonExistentArtifact = Strings.makeRandomId(10);
+        params.configure(VanillaCloudFoundryApplication.ARTIFACT_PATH, nonExistentArtifact);
+        cloudFoundryPaasLocation.deploy(params.getAllConfig());
+    }
+
+    @Test(expectedExceptions = FileSystemNotFoundException.class)
+    public void testUpdateAnNotExistentArtifact() {
+        String nonExistentArtifact = Strings.makeRandomId(10);
+        cloudFoundryPaasLocation.pushArtifact(APPLICATION_NAME, nonExistentArtifact);
     }
 
     @Test
-    public void testStartApplication() throws IOException {
+    public void testStartApplication() {
         ConfigBag params = getDefaultApplicationConfiguration();
         deployApplication(params);
-
-        StartingInfo startingInfo = cloudFoundryPaasLocation.startApplication(APPLICATION_NAME);
-        assertNotNull(startingInfo);
-        assertEquals(startingInfo.getStagingFile(), Strings.EMPTY);
-        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME), AppState.STARTED);
+        cloudFoundryPaasLocation.startApplication(APPLICATION_NAME);
+        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME),
+                AppState.STARTED);
     }
 
-    @Test(expectedExceptions = CloudFoundryException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testStartNonExistentApplication() {
         cloudFoundryPaasLocation.startApplication(APPLICATION_NAME);
     }
 
     @Test
-    public void testGetApplicationStatus() throws IOException {
+    public void testGetApplicationStatus() {
         ConfigBag params = getDefaultApplicationConfiguration();
         deployApplication(params);
-        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME), AppState.STOPPED);
+        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME),
+                AppState.STOPPED);
     }
 
-    @Test(expectedExceptions = CloudFoundryException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testGetStateNonExistentApplication() {
         cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME);
     }
 
     @Test
-    public void testInferApplicationRouteUriNoHost() {
-        ConfigBag params = getDefaultApplicationConfiguration();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, BROOKLYN_DOMAIN);
-        assertEquals(cloudFoundryPaasLocation.inferApplicationRouteUri(params),
-                APPLICATION_NAME + "." + BROOKLYN_DOMAIN);
-    }
-
-    @Test
-    public void testInferApplicationRouteUriWithHost() {
-        ConfigBag params = getDefaultApplicationConfiguration();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, BROOKLYN_DOMAIN);
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_HOST, MOCK_HOST);
-
-        assertEquals(cloudFoundryPaasLocation.inferApplicationRouteUri(params),
-                MOCK_HOST + "." + BROOKLYN_DOMAIN);
-    }
-
-    @Test
-    public void testInferApplicationRouteUriNoDomain() {
-        ConfigBag params = getDefaultResourcesProfile();
-        params.configure(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey(), APPLICATION_NAME);
-
-        assertEquals(cloudFoundryPaasLocation.inferApplicationRouteUri(params),
-                APPLICATION_NAME + "." + BROOKLYN_DOMAIN);
-    }
-
-    @Test
-    public void testStopApplication() throws IOException {
+    public void testStopApplication() {
         ConfigBag params = getDefaultApplicationConfiguration();
         params.configure(VanillaCloudFoundryApplication.APPLICATION_DOMAIN, BROOKLYN_DOMAIN);
         deployApplication(params);
 
         cloudFoundryPaasLocation.startApplication(APPLICATION_NAME);
-        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME), AppState.STARTED);
+        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME),
+                AppState.STARTED);
 
         cloudFoundryPaasLocation.stopApplication(APPLICATION_NAME);
-        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME), AppState.STOPPED);
+        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME),
+                AppState.STOPPED);
     }
 
-    @Test(expectedExceptions = CloudFoundryException.class)
+    @Test(expectedExceptions = RuntimeException.class)
     public void testStopNonExistentApplication() {
         cloudFoundryPaasLocation.stopApplication(APPLICATION_NAME);
     }
 
     @Test
-    public void restartApplication() throws IOException {
+    public void restartApplication() {
         deployApplication(getDefaultApplicationConfiguration());
 
         cloudFoundryPaasLocation.startApplication(APPLICATION_NAME);
-        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME), AppState.STARTED);
+        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME),
+                AppState.STARTED);
 
         cloudFoundryPaasLocation.restartApplication(APPLICATION_NAME);
-        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME), AppState.STARTED);
+        assertEquals(cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME),
+                AppState.STARTED);
     }
 
     @Test
-    public void testDeleteApplication() throws IOException {
+    public void testDeleteApplication() {
         deployApplication(getDefaultApplicationConfiguration());
 
         cloudFoundryPaasLocation.deleteApplication(APPLICATION_NAME);
         assertFalse(cloudFoundryPaasLocation.isDeployed(APPLICATION_NAME));
     }
 
-    @Test(expectedExceptions = CloudFoundryException.class)
+    @Test(expectedExceptions = RuntimeException.class)
     public void testDeleteNonExistentApplication() {
         cloudFoundryPaasLocation.getApplicationStatus(APPLICATION_NAME);
     }
 
     @Test
-    public void testDefaultEmptyEnvConfiguration() throws IOException {
+    public void testDefaultEmptyEnvConfiguration() {
         deployApplication(getDefaultApplicationConfiguration());
         assertTrue(cloudFoundryPaasLocation.getEnv(APPLICATION_NAME).isEmpty());
     }
 
     @Test
-    public void testAddEnvToEmptyApplication() throws IOException {
+    public void testAddEnvToEmptyApplication() {
         deployApplication(getDefaultApplicationConfiguration());
-
         testAdditionOfEnv(MutableMap.<String, String>of(), SIMPLE_ENV);
-        verify(client, times(1)).updateApplicationEnv(APPLICATION_NAME, SIMPLE_ENV);
     }
 
     @Test
-    public void testAddNullEnvToEmptyApplication() throws IOException {
+    public void testAddNullEnvToEmptyApplication() {
         deployApplication(getDefaultApplicationConfiguration());
-
         testAdditionOfEnv(EMPTY_ENV, null);
-        verify(client, never()).updateApplicationEnv(APPLICATION_NAME, EMPTY_ENV);
     }
 
     @Test
@@ -219,54 +204,51 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
         testAdditionOfEnv(cloudFoundryPaasLocation.getEnv(APPLICATION_NAME), defaultEnv);
         joinedEnv.putAll(SIMPLE_ENV);
         testAdditionOfEnv(defaultEnv, SIMPLE_ENV);
-
-        verify(client, times(1)).updateApplicationEnv(APPLICATION_NAME, joinedEnv);
     }
 
     @Test
-    public void testSetMemory() throws IOException {
+    public void testGetMemory() {
+        deployApplication(getDefaultApplicationConfiguration());
+        assertEquals(cloudFoundryPaasLocation.getMemory(APPLICATION_NAME), MEMORY);
+    }
+
+    @Test
+    public void testSetMemory() {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getMemory(APPLICATION_NAME), MEMORY);
 
-        cloudFoundryPaasLocation.setMemory(APPLICATION_NAME, CUSTOM_MEMORY);
+        cloudFoundryPaasLocation.setMemory(APPLICATION_NAME, CUSTOM_MEMORY, APPLICATION_LOCAL_PATH);
         assertEquals(cloudFoundryPaasLocation.getMemory(APPLICATION_NAME), CUSTOM_MEMORY);
-        verify(client, times(1)).updateApplicationMemory(APPLICATION_NAME, CUSTOM_MEMORY);
     }
 
     @Test
-    public void testGetMemory() throws IOException {
-        deployApplication(getDefaultApplicationConfiguration());
-        assertEquals(cloudFoundryPaasLocation.getMemory(APPLICATION_NAME), MEMORY);
-    }
-
-    @Test
-    public void testSetDiskQuota() throws IOException {
+    public void testSetDiskQuota() {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), DISK);
 
-        cloudFoundryPaasLocation.setDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
-        verify(client, times(1)).updateApplicationDiskQuota(APPLICATION_NAME, CUSTOM_DISK);
+        cloudFoundryPaasLocation.setDiskQuota(APPLICATION_NAME, CUSTOM_DISK, APPLICATION_LOCAL_PATH);
+        assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), CUSTOM_DISK);
     }
 
     @Test
-    public void testGetDiskQuota() throws IOException {
+    public void testGetDiskQuota() {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getDiskQuota(APPLICATION_NAME), DISK);
     }
 
     @Test
-    public void testSetIntances() throws IOException {
+    public void testGetInstances() {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getInstancesNumber(APPLICATION_NAME), INSTANCES);
-
-        cloudFoundryPaasLocation.setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES);
-        verify(client, times(1)).updateApplicationInstances(APPLICATION_NAME, CUSTOM_INSTANCES);
     }
 
     @Test
-    public void testGetInstances() throws IOException {
+    public void testSetIntances() {
         deployApplication(getDefaultApplicationConfiguration());
         assertEquals(cloudFoundryPaasLocation.getInstancesNumber(APPLICATION_NAME), INSTANCES);
+
+        cloudFoundryPaasLocation.setInstancesNumber(APPLICATION_NAME, CUSTOM_INSTANCES, APPLICATION_LOCAL_PATH);
+        assertEquals(cloudFoundryPaasLocation.getInstancesNumber(APPLICATION_NAME), CUSTOM_INSTANCES);
     }
 
     private ConfigBag getDefaultApplicationConfiguration() {
@@ -285,10 +267,11 @@ public class CloudFoundryPaasLocationTest extends AbstractCloudFoundryUnitTest {
         return params;
     }
 
-    private void testDeployApplication(ConfigBag params) throws IOException {
-        String applicationDomain = deployApplication(params);
+    private void deployApplicationandCheck(ConfigBag params) {
+        String applicationUrl = deployApplication(params);
+        assertEquals(applicationUrl, inferApplicationUrl(params));
+        assertFalse(Strings.isBlank(applicationUrl));
         String applicationName = params.get(VanillaCloudFoundryApplication.APPLICATION_NAME.getConfigKey());
-        assertEquals(applicationDomain, DEFAULT_APPLICATION_ADDRESS);
         assertEquals(cloudFoundryPaasLocation.getApplicationStatus(applicationName), AppState.STOPPED);
     }
 

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeApplications.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeApplications.java
@@ -270,7 +270,20 @@ public class FakeApplications implements Applications {
 
     @Override
     public Mono<Void> scale(ScaleApplicationRequest request) {
-        return null;
+        String name = request.getName();
+        ApplicationDetail application = applications.get(name);
+        ApplicationDetail.Builder builder = ApplicationDetail.builder().from(application);
+        if (request.getMemoryLimit() != null) {
+            builder.memoryLimit(request.getMemoryLimit());
+        }
+        if (request.getDiskLimit() != null) {
+            builder.diskQuota(request.getDiskLimit());
+        }
+        if (request.getInstances() != null) {
+            builder.instances(request.getInstances());
+        }
+        applications.put(name, builder.build());
+        return Mono.empty();
     }
 
     @Override

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeApplications.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeApplications.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.cloudfoundry.location;
+
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.apache.brooklyn.cloudfoundry.AbstractCloudFoundryUnitTest;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.text.Strings;
+import org.cloudfoundry.doppler.LogMessage;
+import org.cloudfoundry.operations.applications.ApplicationDetail;
+import org.cloudfoundry.operations.applications.ApplicationEnvironments;
+import org.cloudfoundry.operations.applications.ApplicationEvent;
+import org.cloudfoundry.operations.applications.ApplicationHealthCheck;
+import org.cloudfoundry.operations.applications.ApplicationManifest;
+import org.cloudfoundry.operations.applications.ApplicationSshEnabledRequest;
+import org.cloudfoundry.operations.applications.ApplicationSummary;
+import org.cloudfoundry.operations.applications.Applications;
+import org.cloudfoundry.operations.applications.CopySourceApplicationRequest;
+import org.cloudfoundry.operations.applications.DeleteApplicationRequest;
+import org.cloudfoundry.operations.applications.DisableApplicationSshRequest;
+import org.cloudfoundry.operations.applications.EnableApplicationSshRequest;
+import org.cloudfoundry.operations.applications.GetApplicationEnvironmentsRequest;
+import org.cloudfoundry.operations.applications.GetApplicationEventsRequest;
+import org.cloudfoundry.operations.applications.GetApplicationHealthCheckRequest;
+import org.cloudfoundry.operations.applications.GetApplicationManifestRequest;
+import org.cloudfoundry.operations.applications.GetApplicationRequest;
+import org.cloudfoundry.operations.applications.LogsRequest;
+import org.cloudfoundry.operations.applications.PushApplicationRequest;
+import org.cloudfoundry.operations.applications.RenameApplicationRequest;
+import org.cloudfoundry.operations.applications.RestageApplicationRequest;
+import org.cloudfoundry.operations.applications.RestartApplicationInstanceRequest;
+import org.cloudfoundry.operations.applications.RestartApplicationRequest;
+import org.cloudfoundry.operations.applications.ScaleApplicationRequest;
+import org.cloudfoundry.operations.applications.SetApplicationHealthCheckRequest;
+import org.cloudfoundry.operations.applications.SetEnvironmentVariableApplicationRequest;
+import org.cloudfoundry.operations.applications.StartApplicationRequest;
+import org.cloudfoundry.operations.applications.StopApplicationRequest;
+import org.cloudfoundry.operations.applications.UnsetEnvironmentVariableApplicationRequest;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class FakeApplications implements Applications {
+
+    private static final String DEFAULT_DOMAIN = AbstractCloudFoundryUnitTest.BROOKLYN_DOMAIN;
+    private static final String DEFAULT_STACK = "cflinuxfs2";
+    private static final String STARTED = "STARTED";
+    private static final String STOPPED = "STOPPED";
+    private static final int ID_SIZE = 36;
+
+    private Map<String, ApplicationDetail> applications;
+    private Map<String, Map<String, String>> applicationEnv;
+
+    public FakeApplications() {
+        applications = MutableMap.of();
+        applicationEnv = MutableMap.of();
+    }
+
+    @Override
+    public Mono<Void> push(PushApplicationRequest request) {
+        checkApplicationPath(request);
+        String name = request.getName();
+        if (!applications.containsKey(name)) {
+            manageNewReques(request);
+        } else {
+            updateApplication(request);
+        }
+        return Mono.empty();
+    }
+
+    private void checkApplicationPath(PushApplicationRequest request) {
+        if (request.getApplication() == null) {
+            throw new IllegalStateException("Cannot build PushApplicationRequest, " +
+                    "some of required attributes are not set [application]");
+        }
+        Path artifactPath = request.getApplication();
+        if (!Files.exists(artifactPath) || artifactPath.toString().equals(Strings.EMPTY)) {
+            throw new FileSystemNotFoundException("Not found: " + artifactPath.toString());
+        }
+    }
+
+    private void manageNewReques(PushApplicationRequest request) {
+        applications.put(request.getName(), ApplicationDetail.builder()
+                .name(request.getName())
+                .buildpack(request.getBuildpack())
+                .stack(DEFAULT_STACK)
+                .id(generateApplicationId())
+                .memoryLimit(request.getMemory())
+                .diskQuota(request.getDiskQuota())
+                .instances(request.getInstances())
+                .runningInstances(request.getInstances())
+                .requestedState(STOPPED)
+                .url(getUrl(request))
+                .build());
+        initEnv(request);
+    }
+
+    private String generateApplicationId() {
+        return Strings.makeRandomId(ID_SIZE);
+    }
+
+    private String getUrl(PushApplicationRequest request) {
+        return composeApplicationUrl(findHostName(request), getValidDomain(request));
+    }
+
+    private String findHostName(PushApplicationRequest request) {
+        String host = request.getHost();
+        if (Strings.isBlank(host)) {
+            host = request.getName();
+        }
+        return host;
+    }
+
+    private String getValidDomain(PushApplicationRequest request) {
+        String domain = request.getDomain();
+        if (Strings.isBlank(domain) || domain.equals(DEFAULT_DOMAIN)) {
+            return DEFAULT_DOMAIN;
+        }
+        throw new IllegalStateException("Domain " + domain + " not found");
+    }
+
+    private String composeApplicationUrl(String host, String domain) {
+        return host + "." + domain;
+    }
+
+    private void initEnv(PushApplicationRequest request) {
+        applicationEnv.put(request.getName(), MutableMap.<String, String>of());
+    }
+
+    private void updateApplication(PushApplicationRequest request) {
+        updateMemory(request);
+        updateDiskQuota(request);
+        updateInstances(request);
+    }
+
+    private void updateMemory(PushApplicationRequest request) {
+        if (request.getMemory() != null) {
+            String applicationName = request.getName();
+            ApplicationDetail baseApplicationDetail = applications.get(applicationName);
+            applications.put(request.getName(), ApplicationDetail.builder()
+                    .from(baseApplicationDetail)
+                    .memoryLimit(request.getMemory())
+                    .build());
+        }
+    }
+
+    private void updateDiskQuota(PushApplicationRequest request) {
+        if (request.getDiskQuota() != null) {
+            String applicationName = request.getName();
+            ApplicationDetail baseApplicationDetail = applications.get(applicationName);
+            applications.put(request.getName(), ApplicationDetail.builder()
+                    .from(baseApplicationDetail)
+                    .diskQuota(request.getDiskQuota())
+                    .build());
+        }
+    }
+
+    private void updateInstances(PushApplicationRequest request) {
+        if (request.getInstances() != null) {
+            String applicationName = request.getName();
+            ApplicationDetail baseApplicationDetail = applications.get(applicationName);
+            applications.put(request.getName(), ApplicationDetail.builder()
+                    .from(baseApplicationDetail)
+                    .instances(request.getInstances())
+                    .build());
+        }
+    }
+
+    @Override
+    public Mono<Void> copySource(CopySourceApplicationRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> delete(DeleteApplicationRequest request) {
+        ApplicationDetail application = getApplication(request.getName());
+        applications.remove(application.getName());
+        applicationEnv.remove(application.getName());
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> disableSsh(DisableApplicationSshRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> enableSsh(EnableApplicationSshRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<ApplicationDetail> get(GetApplicationRequest request) {
+        return Mono.just(getApplication(request.getName()));
+    }
+
+    @Override
+    public Mono<ApplicationManifest> getApplicationManifest(GetApplicationManifestRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<ApplicationEnvironments> getEnvironments(GetApplicationEnvironmentsRequest request) {
+        ApplicationDetail application = getApplication(request.getName());
+        Map<String, String> userEnv = applicationEnv.get(application.getName());
+        return Mono.just(ApplicationEnvironments.builder()
+                .userProvided(userEnv).build());
+    }
+
+    @Override
+    public Flux<ApplicationEvent> getEvents(GetApplicationEventsRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<ApplicationHealthCheck> getHealthCheck(GetApplicationHealthCheckRequest request) {
+        return null;
+    }
+
+    @Override
+    public Flux<ApplicationSummary> list() {
+        return null;
+    }
+
+    @Override
+    public Flux<LogMessage> logs(LogsRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> rename(RenameApplicationRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> restage(RestageApplicationRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> restart(RestartApplicationRequest request) {
+        setStartedState(request.getName());
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> restartInstance(RestartApplicationInstanceRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> scale(ScaleApplicationRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> setEnvironmentVariable(SetEnvironmentVariableApplicationRequest request) {
+        ApplicationDetail application = applications.get(request.getName());
+        applicationEnv.get(application.getName())
+                .put(request.getVariableName(), request.getVariableValue());
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> setHealthCheck(SetApplicationHealthCheckRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Boolean> sshEnabled(ApplicationSshEnabledRequest request) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> start(StartApplicationRequest request) {
+        setStartedState(request.getName());
+        return Mono.empty();
+    }
+
+    private Void setStartedState(String name) {
+        ApplicationDetail baseApplication = getApplication(name);
+        applications.put(name, ApplicationDetail.builder()
+                .from(baseApplication)
+                .requestedState(STARTED).build());
+        return null;
+    }
+
+    private Void setStoppedState(String name) {
+        ApplicationDetail baseApplication = getApplication(name);
+        applications.put(name, ApplicationDetail.builder()
+                .from(baseApplication)
+                .requestedState(STOPPED).build());
+        return null;
+    }
+
+    private ApplicationDetail getApplication(String name) {
+        if (!applications.containsKey(name)) {
+            throw new IllegalStateException(" Application " + name + " does not exist");
+        }
+        return applications.get(name);
+    }
+
+    @Override
+    public Mono<Void> stop(StopApplicationRequest request) {
+        setStoppedState(request.getName());
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> unsetEnvironmentVariable(UnsetEnvironmentVariableApplicationRequest request) {
+        return null;
+    }
+}

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClient.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/FakeCloudFoundryClient.java
@@ -18,748 +18,87 @@
  */
 package org.apache.brooklyn.cloudfoundry.location;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.text.Strings;
-import org.cloudfoundry.client.lib.ApplicationLogListener;
-import org.cloudfoundry.client.lib.ClientHttpResponseCallback;
-import org.cloudfoundry.client.lib.CloudCredentials;
-import org.cloudfoundry.client.lib.CloudFoundryException;
-import org.cloudfoundry.client.lib.CloudFoundryOperations;
-import org.cloudfoundry.client.lib.RestLogCallback;
-import org.cloudfoundry.client.lib.StartingInfo;
-import org.cloudfoundry.client.lib.StreamingLogToken;
-import org.cloudfoundry.client.lib.UploadStatusCallback;
-import org.cloudfoundry.client.lib.archive.ApplicationArchive;
-import org.cloudfoundry.client.lib.domain.ApplicationLog;
-import org.cloudfoundry.client.lib.domain.ApplicationStats;
-import org.cloudfoundry.client.lib.domain.CloudApplication;
-import org.cloudfoundry.client.lib.domain.CloudDomain;
-import org.cloudfoundry.client.lib.domain.CloudEvent;
-import org.cloudfoundry.client.lib.domain.CloudInfo;
-import org.cloudfoundry.client.lib.domain.CloudOrganization;
-import org.cloudfoundry.client.lib.domain.CloudQuota;
-import org.cloudfoundry.client.lib.domain.CloudRoute;
-import org.cloudfoundry.client.lib.domain.CloudSecurityGroup;
-import org.cloudfoundry.client.lib.domain.CloudService;
-import org.cloudfoundry.client.lib.domain.CloudServiceBroker;
-import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
-import org.cloudfoundry.client.lib.domain.CloudServiceOffering;
-import org.cloudfoundry.client.lib.domain.CloudSpace;
-import org.cloudfoundry.client.lib.domain.CloudStack;
-import org.cloudfoundry.client.lib.domain.CloudUser;
-import org.cloudfoundry.client.lib.domain.CrashesInfo;
-import org.cloudfoundry.client.lib.domain.InstancesInfo;
-import org.cloudfoundry.client.lib.domain.Staging;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.oauth2.common.OAuth2AccessToken;
-import org.springframework.web.client.ResponseErrorHandler;
-
-import com.squareup.okhttp.mockwebserver.Dispatcher;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import org.cloudfoundry.operations.CloudFoundryOperations;
+import org.cloudfoundry.operations.advanced.Advanced;
+import org.cloudfoundry.operations.applications.Applications;
+import org.cloudfoundry.operations.buildpacks.Buildpacks;
+import org.cloudfoundry.operations.domains.Domains;
+import org.cloudfoundry.operations.organizationadmin.OrganizationAdmin;
+import org.cloudfoundry.operations.organizations.Organizations;
+import org.cloudfoundry.operations.routes.Routes;
+import org.cloudfoundry.operations.serviceadmin.ServiceAdmin;
+import org.cloudfoundry.operations.services.Services;
+import org.cloudfoundry.operations.spaceadmin.SpaceAdmin;
+import org.cloudfoundry.operations.spaces.Spaces;
+import org.cloudfoundry.operations.stacks.Stacks;
 
 
 public class FakeCloudFoundryClient implements CloudFoundryOperations {
 
-    private static final String BROOKLYN_DOMAIN = "brooklyndomain.io";
-
-    private Map<String, CloudApplication> applications;
+    private Applications applications;
 
     public FakeCloudFoundryClient() {
-        applications = MutableMap.of();
+        applications = new FakeApplications();
     }
 
     @Override
-    public void createApplication(String appName, Staging staging, Integer disk, Integer memory, List<String> uris, List<String> serviceNames) {
-        createApplication(appName, staging, memory, uris, serviceNames);
-        applications.get(appName).setDiskQuota(disk);
-    }
-
-    @Override
-    public void createApplication(String appName, Staging staging, Integer memory, List<String> uris, List<String> serviceNames) {
-        CloudApplication app = new CloudApplication(appName, null, null, memory, 1, uris, serviceNames, CloudApplication.AppState.STOPPED);
-        applications.put(appName, app);
-    }
-
-    @Override
-    public CloudApplication getApplication(String appName) {
-        CloudApplication application = applications.get(appName);
-        if (application == null) {
-            throw new CloudFoundryException(HttpStatus.NOT_FOUND);
-        }
-        return application;
-    }
-
-    @Override
-    public void uploadApplication(String appName, String file) throws IOException {
-        if (!Files.exists(Paths.get(file))) {
-            throw new FileNotFoundException("File :" + file + " was not found by " + this);
-        }
-    }
-
-    @Override
-    public void uploadApplication(String appName, File file) throws IOException {
-        //nothing
-    }
-
-    @Override
-    public void uploadApplication(String appName, File file, UploadStatusCallback callback) throws IOException {
-        //nothing
-    }
-
-    @Override
-    public void uploadApplication(String appName, String fileName, InputStream inputStream) throws IOException {
-        //nothing
-    }
-
-    @Override
-    public void uploadApplication(String appName, String fileName, InputStream inputStream, UploadStatusCallback callback) throws IOException {
-        //nothing
-    }
-
-    @Override
-    public void uploadApplication(String appName, ApplicationArchive archive) throws IOException {
-        //nothing
-    }
-
-    @Override
-    public void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException {
-        //nothing
-    }
-
-    @Override
-    public StartingInfo startApplication(String appName) {
-        CloudApplication application = getApplication(appName);
-        application.setState(CloudApplication.AppState.STARTED);
-        return new StartingInfo(Strings.EMPTY);
-    }
-
-    @Override
-    public void debugApplication(String appName, CloudApplication.DebugMode mode) {
-
-    }
-
-    @Override
-    public void stopApplication(String appName) {
-        CloudApplication application = getApplication(appName);
-        application.setState(CloudApplication.AppState.STOPPED);
-    }
-
-    @Override
-    public StartingInfo restartApplication(String appName) {
-        return startApplication(appName);
-    }
-
-    @Override
-    public void deleteApplication(String appName) {
-        applications.remove(appName);
-    }
-
-    @Override
-    public void deleteAllApplications() {
-
-    }
-
-    @Override
-    public void deleteAllServices() {
-
-    }
-
-    @Override
-    public void updateApplicationDiskQuota(String appName, int disk) {
-        CloudApplication application = getApplication(appName);
-        application.setDiskQuota(disk);
-    }
-
-    @Override
-    public void updateApplicationMemory(String appName, int memory) {
-        CloudApplication application = getApplication(appName);
-        application.setMemory(memory);
-    }
-
-    @Override
-    public void updateApplicationInstances(String appName, int instances) {
-        CloudApplication application = getApplication(appName);
-        application.setInstances(instances);
-    }
-
-    @Override
-    public void updateApplicationServices(String appName, List<String> services) {
-
-    }
-
-    @Override
-    public void updateApplicationStaging(String appName, Staging staging) {
-
-    }
-
-    @Override
-    public void updateApplicationUris(String appName, List<String> uris) {
-
-    }
-
-    @Override
-    public void updateApplicationEnv(String appName, Map<String, String> env) {
-        Map<Object, Object> newEnv = MutableMap.of();
-        newEnv.putAll(env);
-        getApplication(appName).setEnv(newEnv);
-    }
-
-    @Override
-    public void setResponseErrorHandler(ResponseErrorHandler errorHandler) {
-
-    }
-
-    @Override
-    public URL getCloudControllerUrl() {
+    public Advanced advanced() {
         return null;
     }
 
     @Override
-    public CloudInfo getCloudInfo() {
+    public Applications applications() {
+        return applications;
+    }
+
+    @Override
+    public Buildpacks buildpacks() {
         return null;
     }
 
     @Override
-    public List<CloudSpace> getSpaces() {
+    public Domains domains() {
         return null;
     }
 
     @Override
-    public List<UUID> getSpaceManagers(String spaceName) {
+    public OrganizationAdmin organizationAdmin() {
         return null;
     }
 
     @Override
-    public List<UUID> getSpaceDevelopers(String spaceName) {
+    public Organizations organizations() {
         return null;
     }
 
     @Override
-    public List<UUID> getSpaceAuditors(String spaceName) {
+    public Routes routes() {
         return null;
     }
 
     @Override
-    public List<UUID> getSpaceManagers(String orgName, String spaceName) {
+    public ServiceAdmin serviceAdmin() {
         return null;
     }
 
     @Override
-    public List<UUID> getSpaceDevelopers(String orgName, String spaceName) {
+    public Services services() {
         return null;
     }
 
     @Override
-    public List<UUID> getSpaceAuditors(String orgName, String spaceName) {
+    public SpaceAdmin spaceAdmin() {
         return null;
     }
 
     @Override
-    public void associateAuditorWithSpace(String spaceName) {
-
-    }
-
-    @Override
-    public void associateDeveloperWithSpace(String spaceName) {
-
-    }
-
-    @Override
-    public void associateManagerWithSpace(String spaceName) {
-
-    }
-
-    @Override
-    public void associateAuditorWithSpace(String orgName, String spaceName) {
-
-    }
-
-    @Override
-    public void associateDeveloperWithSpace(String orgName, String spaceName) {
-
-    }
-
-    @Override
-    public void associateManagerWithSpace(String orgName, String spaceName) {
-
-    }
-
-    @Override
-    public void associateAuditorWithSpace(String orgName, String spaceName, String userGuid) {
-
-    }
-
-    @Override
-    public void associateDeveloperWithSpace(String orgName, String spaceName, String userGuid) {
-
-    }
-
-    @Override
-    public void associateManagerWithSpace(String orgName, String spaceName, String userGuid) {
-
-    }
-
-    @Override
-    public void createSpace(String spaceName) {
-
-    }
-
-    @Override
-    public CloudSpace getSpace(String spaceName) {
+    public Spaces spaces() {
         return null;
     }
 
     @Override
-    public void deleteSpace(String spaceName) {
-
-    }
-
-    @Override
-    public List<CloudOrganization> getOrganizations() {
+    public Stacks stacks() {
         return null;
     }
 
-    @Override
-    public CloudOrganization getOrgByName(String orgName, boolean required) {
-        return null;
-    }
-
-    @Override
-    public void register(String email, String password) {
-
-    }
-
-    @Override
-    public void updatePassword(String newPassword) {
-
-    }
-
-    @Override
-    public void updatePassword(CloudCredentials credentials, String newPassword) {
-
-    }
-
-    @Override
-    public void unregister() {
-
-    }
-
-    @Override
-    public OAuth2AccessToken login() {
-        return null;
-    }
-
-    @Override
-    public void logout() {
-
-    }
-
-    @Override
-    public List<CloudApplication> getApplications() {
-        return null;
-    }
-
-    @Override
-    public CloudApplication getApplication(UUID guid) {
-        return null;
-    }
-
-    @Override
-    public ApplicationStats getApplicationStats(String appName) {
-        return null;
-    }
-
-    @Override
-    public Map<String, Object> getApplicationEnvironment(String appName) {
-        return null;
-    }
-
-    @Override
-    public Map<String, Object> getApplicationEnvironment(UUID appGuid) {
-        return null;
-    }
-
-    @Override
-    public void createService(CloudService service) {
-
-    }
-
-    @Override
-    public void createUserProvidedService(CloudService service, Map<String, Object> credentials) {
-
-    }
-
-    @Override
-    public void createUserProvidedService(CloudService service, Map<String, Object> credentials, String syslogDrainUrl) {
-
-    }
-
-    @Override
-    public List<CloudRoute> deleteOrphanedRoutes() {
-        return null;
-    }
-
-    @Override
-    public void updateApplicationEnv(String appName, List<String> env) {
-
-    }
-
-    @Override
-    public List<CloudEvent> getEvents() {
-        return null;
-    }
-
-    @Override
-    public List<CloudEvent> getApplicationEvents(String appName) {
-        return null;
-    }
-
-    @Override
-    public Map<String, String> getLogs(String appName) {
-        return null;
-    }
-
-    @Override
-    public StreamingLogToken streamLogs(String appName, ApplicationLogListener listener) {
-        return null;
-    }
-
-    @Override
-    public List<ApplicationLog> getRecentLogs(String appName) {
-        return null;
-    }
-
-    @Override
-    public Map<String, String> getCrashLogs(String appName) {
-        return null;
-    }
-
-    @Override
-    public String getStagingLogs(StartingInfo info, int offset) {
-        return null;
-    }
-
-    @Override
-    public List<CloudStack> getStacks() {
-        return null;
-    }
-
-    @Override
-    public CloudStack getStack(String name) {
-        return null;
-    }
-
-    @Override
-    public String getFile(String appName, int instanceIndex, String filePath) {
-        return null;
-    }
-
-    @Override
-    public String getFile(String appName, int instanceIndex, String filePath, int startPosition) {
-        return null;
-    }
-
-    @Override
-    public String getFile(String appName, int instanceIndex, String filePath, int startPosition, int endPosition) {
-        return null;
-    }
-
-    @Override
-    public String getFileTail(String appName, int instanceIndex, String filePath, int length) {
-        return null;
-    }
-
-    @Override
-    public void openFile(String appName, int instanceIndex, String filePath, ClientHttpResponseCallback clientHttpResponseCallback) {
-
-    }
-
-    @Override
-    public List<CloudService> getServices() {
-        return null;
-    }
-
-    @Override
-    public CloudService getService(String service) {
-        return null;
-    }
-
-    @Override
-    public CloudServiceInstance getServiceInstance(String service) {
-        return null;
-    }
-
-    @Override
-    public void deleteService(String service) {
-
-    }
-
-    @Override
-    public List<CloudServiceOffering> getServiceOfferings() {
-        return null;
-    }
-
-    @Override
-    public List<CloudServiceBroker> getServiceBrokers() {
-        return null;
-    }
-
-    @Override
-    public CloudServiceBroker getServiceBroker(String name) {
-        return null;
-    }
-
-    @Override
-    public void createServiceBroker(CloudServiceBroker serviceBroker) {
-
-    }
-
-    @Override
-    public void updateServiceBroker(CloudServiceBroker serviceBroker) {
-
-    }
-
-    @Override
-    public void deleteServiceBroker(String name) {
-
-    }
-
-    @Override
-    public void updateServicePlanVisibilityForBroker(String name, boolean visibility) {
-
-    }
-
-    @Override
-    public void bindService(String appName, String serviceName) {
-
-    }
-
-    @Override
-    public void unbindService(String appName, String serviceName) {
-
-    }
-
-    @Override
-    public InstancesInfo getApplicationInstances(String appName) {
-        return null;
-    }
-
-    @Override
-    public InstancesInfo getApplicationInstances(CloudApplication app) {
-        return null;
-    }
-
-    @Override
-    public CrashesInfo getCrashes(String appName) {
-        return null;
-    }
-
-    @Override
-    public void rename(String appName, String newName) {
-
-    }
-
-    @Override
-    public List<CloudDomain> getDomainsForOrg() {
-        return null;
-    }
-
-    @Override
-    public List<CloudDomain> getPrivateDomains() {
-        return null;
-    }
-
-    @Override
-    public List<CloudDomain> getSharedDomains() {
-        return MutableList.of(new CloudDomain(null, BROOKLYN_DOMAIN, null));
-    }
-
-    @Override
-    public List<CloudDomain> getDomains() {
-        return MutableList.of(new CloudDomain(null, BROOKLYN_DOMAIN, null));
-    }
-
-    @Override
-    public CloudDomain getDefaultDomain() {
-        return new CloudDomain(null, BROOKLYN_DOMAIN, null);
-    }
-
-    @Override
-    public void addDomain(String domainName) {
-
-    }
-
-    @Override
-    public void removeDomain(String domainName) {
-
-    }
-
-    @Override
-    public void deleteDomain(String domainName) {
-
-    }
-
-    @Override
-    public List<CloudRoute> getRoutes(String domainName) {
-        return null;
-    }
-
-    @Override
-    public void addRoute(String host, String domainName) {
-
-    }
-
-    @Override
-    public void deleteRoute(String host, String domainName) {
-
-    }
-
-    @Override
-    public void registerRestLogListener(RestLogCallback callBack) {
-
-    }
-
-    @Override
-    public void unRegisterRestLogListener(RestLogCallback callBack) {
-
-    }
-
-    @Override
-    public CloudQuota getQuotaByName(String quotaName, boolean required) {
-        return null;
-    }
-
-    @Override
-    public void setQuotaToOrg(String orgName, String quotaName) {
-
-    }
-
-    @Override
-    public void createQuota(CloudQuota quota) {
-
-    }
-
-    @Override
-    public void deleteQuota(String quotaName) {
-
-    }
-
-    @Override
-    public List<CloudQuota> getQuotas() {
-        return null;
-    }
-
-    @Override
-    public void updateQuota(CloudQuota quota, String name) {
-
-    }
-
-    @Override
-    public List<CloudSecurityGroup> getSecurityGroups() {
-        return null;
-    }
-
-    @Override
-    public CloudSecurityGroup getSecurityGroup(String securityGroupName) {
-        return null;
-    }
-
-    @Override
-    public void createSecurityGroup(CloudSecurityGroup securityGroup) {
-
-    }
-
-    @Override
-    public void createSecurityGroup(String name, InputStream jsonRulesFile) {
-
-    }
-
-    @Override
-    public void updateSecurityGroup(CloudSecurityGroup securityGroup) {
-
-    }
-
-    @Override
-    public void updateSecurityGroup(String name, InputStream jsonRulesFile) {
-
-    }
-
-    @Override
-    public void deleteSecurityGroup(String securityGroupName) {
-
-    }
-
-    @Override
-    public List<CloudSecurityGroup> getStagingSecurityGroups() {
-        return null;
-    }
-
-    @Override
-    public void bindStagingSecurityGroup(String securityGroupName) {
-
-    }
-
-    @Override
-    public void unbindStagingSecurityGroup(String securityGroupName) {
-
-    }
-
-    @Override
-    public List<CloudSecurityGroup> getRunningSecurityGroups() {
-        return null;
-    }
-
-    @Override
-    public void bindRunningSecurityGroup(String securityGroupName) {
-
-    }
-
-    @Override
-    public void unbindRunningSecurityGroup(String securityGroupName) {
-
-    }
-
-    @Override
-    public List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName) {
-        return null;
-    }
-
-    @Override
-    public void bindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
-
-    }
-
-    @Override
-    public void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName) {
-
-    }
-
-    @Override
-    public Map<String, CloudUser> getOrganizationUsers(String orgName) {
-        return null;
-    }
-
-    private Dispatcher getGenericDispatcher() {
-        return new Dispatcher() {
-            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
-                if (request.getPath().equals("/")) {
-                    return new MockResponse().setResponseCode(200);
-                }
-                return new MockResponse().setResponseCode(404);
-            }
-        };
-    }
 }

--- a/src/test/java/org/apache/brooklyn/cloudfoundry/location/StubbedCloudFoundryPaasClientRegistry.java
+++ b/src/test/java/org/apache/brooklyn/cloudfoundry/location/StubbedCloudFoundryPaasClientRegistry.java
@@ -21,7 +21,7 @@ package org.apache.brooklyn.cloudfoundry.location;
 import static org.mockito.Mockito.spy;
 
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.cloudfoundry.client.lib.CloudFoundryOperations;
+import org.cloudfoundry.operations.CloudFoundryOperations;
 
 public class StubbedCloudFoundryPaasClientRegistry implements CloudFoundryClientRegistry {
 

--- a/src/test/resources/cloudfoundry-location-example.yml
+++ b/src/test/resources/cloudfoundry-location-example.yml
@@ -25,9 +25,6 @@ location:
     endpoint: https://api.run.secret.io
     space: development
     address: run.secret.io
-    memory: 1024
-    disk_quota: 10
-    instances: 1
 services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudfoundryApplication
   id: vanilla-app

--- a/src/test/resources/vanilla-cf-app-name.yml
+++ b/src/test/resources/vanilla-cf-app-name.yml
@@ -16,20 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: CloudFoundryPaasLocation configuration example
-location:
-  cloudfoundry:
-    user: user@mail.com
-    password: secret
-    org: secret_organization
-    endpoint: https://api.run.secret.io
-    space: development
+name: Vanilla CloudFoundry application using a name
+location: pivotal-ws
 services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name-app: name
+    name-app: vanilla-cf-app-example
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
-    domain: domain
-    host: application-host

--- a/src/test/resources/vanilla-cf-app-name.yml
+++ b/src/test/resources/vanilla-cf-app-name.yml
@@ -22,6 +22,6 @@ services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name-app: vanilla-cf-app-example
+    nameApp: vanilla-cf-app-example
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git

--- a/src/test/resources/vanilla-cf-domain.yml
+++ b/src/test/resources/vanilla-cf-domain.yml
@@ -16,20 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: CloudFoundryPaasLocation configuration example
-location:
-  cloudfoundry:
-    user: user@mail.com
-    password: secret
-    org: secret_organization
-    endpoint: https://api.run.secret.io
-    space: development
+name: Vanilla CloudFoundry application using a domain
+location: pivotal-ws
 services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name-app: name
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
-    domain: domain
-    host: application-host
+    domain: cfapps.io

--- a/src/test/resources/vanilla-cf-env.yml
+++ b/src/test/resources/vanilla-cf-env.yml
@@ -16,16 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Vanilla CloudFoundry example with env
+name: Vanilla CloudFoundry application with env
 location: pivotal-ws
 services:
-- type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudfoundryApplication
+- type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name: vanilla-cf-env-example
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
-    domain: cfapps.io
     env:
       env1: value1
       env2: 2

--- a/src/test/resources/vanilla-cf-host-and-domain.yml
+++ b/src/test/resources/vanilla-cf-host-and-domain.yml
@@ -22,7 +22,7 @@ services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name-app: vanilla-cf-app-example
+    nameApp: vanilla-cf-app-example
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
     host: brooklyn-test-host

--- a/src/test/resources/vanilla-cf-host-and-domain.yml
+++ b/src/test/resources/vanilla-cf-host-and-domain.yml
@@ -16,16 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Vanilla CloudFoundry example
+name: Vanilla CloudFoundry using host and domain to configure the application
 location: pivotal-ws
 services:
-- type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudfoundryApplication
+- type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name: vanilla-cf-app-example
+    name-app: vanilla-cf-app-example
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
+    host: brooklyn-test-host
     domain: cfapps.io
-    memory: 512
-    disk_quota: 2048
-    instances: 1

--- a/src/test/resources/vanilla-cf-resources-profile.yml
+++ b/src/test/resources/vanilla-cf-resources-profile.yml
@@ -16,20 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: CloudFoundryPaasLocation configuration example
-location:
-  cloudfoundry:
-    user: user@mail.com
-    password: secret
-    org: secret_organization
-    endpoint: https://api.run.secret.io
-    space: development
+name: Vanilla CloudFoundry application with resource profile configuration
+location: pivotal-ws
 services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name-app: name
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
-    domain: domain
-    host: application-host
+    memory: 1024
+    disk_quota: 2048
+    instances: 1

--- a/src/test/resources/vanilla-cf-standalone.yml
+++ b/src/test/resources/vanilla-cf-standalone.yml
@@ -16,20 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: CloudFoundryPaasLocation configuration example
-location:
-  cloudfoundry:
-    user: user@mail.com
-    password: secret
-    org: secret_organization
-    endpoint: https://api.run.secret.io
-    space: development
+name: Vanilla CloudFoundry example
+location: pivotal-ws
 services:
 - type: org.apache.brooklyn.cloudfoundry.entity.VanillaCloudFoundryApplication
   id: vanilla-app
   brooklyn.config:
-    name-app: name
     path: classpath://brooklyn-example-hello-world-sql-webapp-in-paas.war
     buildpack: https://github.com/cloudfoundry/java-buildpack.git
-    domain: domain
-    host: application-host


### PR DESCRIPTION
This PR updates the `cf-java-client` from `1.1.3` to `2.0.0-SNAPSHOT`.

This new version maintain the major part of the old interface, but it is based on [reactor-core](https://github.com/reactor/reactor-core) so a lot aspect about the management were modified, for example `Mono` and `Flux` element are required to support the new client version.

This PR is based on #15 
